### PR TITLE
Child pixel removal and strategy start-/end-date fix

### DIFF
--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -155,9 +155,14 @@ class Entity(Connection):
         return datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=FixedOffset(offset))
 
     @staticmethod
-    def _strft(dt_obj):
+    def _strft(dt_obj, null_on_none=False):
         """Convert datetime.datetime to ISO string"""
-        return dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
+        try:
+            return dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
+        except AttributeError:
+            if dt_obj is None and null_on_none:
+                return ""
+            raise
 
     def _validate_read(self, data):
         """Convert XML strings to Python objects"""

--- a/terminalone/models/pixel.py
+++ b/terminalone/models/pixel.py
@@ -32,3 +32,12 @@ class ChildPixel(Entity):
 
     def __init__(self, session, properties=None, **kwargs):
         super(ChildPixel, self).__init__(session, properties, **kwargs)
+
+    def remove(self):
+        """Remove the pixel from the container."""
+        url = '/'.join([self.collection,
+                        str(self.id),
+                        'delete'])
+        self._post(PATHS['mgmt'], rest=url, data={'version': self.version})
+        for item in list(self.properties.keys()):
+            del self.properties[item]

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -2,6 +2,7 @@
 """Provides strategy object."""
 
 from __future__ import absolute_import
+from functools import partial
 import re
 from ..config import PATHS
 from ..entity import Entity
@@ -82,7 +83,7 @@ class Strategy(Entity):
         'audience_segment_exclude_op': _aud_seg_exc,
         'audience_segment_include_op': _aud_seg_inc,
         'bid_price_is_media_only': int,
-        'end_date': Entity._strft,
+        'end_date': partial(Entity._strft, null_on_none=True),
         'frequency_interval': _freq_int,
         'frequency_type': _freq_type,
         'goal_type': _goal_type,
@@ -96,7 +97,7 @@ class Strategy(Entity):
         'run_on_streaming': int,
         'site_restriction_transparent_urls': int,
         'site_selectiveness': _site_selec,
-        'start_date': Entity._strft,
+        'start_date': partial(Entity._strft, null_on_none=True),
         'status': int,
         'supply_type': _supply_type,
         'type': _type,
@@ -183,10 +184,10 @@ class Strategy(Entity):
         if data is None:
             data = self.properties.copy()
 
-        if getattr(self, 'use_campaign_start', False):
-            data.pop('start_date', None)
-        if getattr(self, 'use_campaign_end', False):
-            data.pop('end_date', None)
+        if getattr(self, 'use_campaign_start', False) and 'start_date' in data:
+            data['start_date'] = None
+        if getattr(self, 'use_campaign_end', False) and 'end_date' in data:
+            data['end_date'] = None
 
         super(Strategy, self).save(data=data, url=url)
 

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -185,8 +185,10 @@ class Strategy(Entity):
             data = self.properties.copy()
 
         if getattr(self, 'use_campaign_start', False) and 'start_date' in data:
+            self.properties.pop('start_date', None)
             data['start_date'] = None
         if getattr(self, 'use_campaign_end', False) and 'end_date' in data:
+            self.properties.pop('end_date', None)
             data['end_date'] = None
 
         super(Strategy, self).save(data=data, url=url)


### PR DESCRIPTION
- Strategy start/end dates have a weird dual setup. You can choose to
use the campaign dates or set custom ones. If the former, you cannot
post custom start-end dates, and so `Strategy.save` removes those from
the body. However, if you are changing a strategy from having start/end
dates to using campaign start/end dates, you are supposed to POST a
null value. So we need to convert the None to an empty string.
- Add removal for `ChildPixel`. This enables removal of a piggybacked pixel from a container.