### PR TITLE
Add property check to enable pre-addition validation.

### DIFF
--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -223,6 +223,11 @@ class Entity(Connection):
         for key, value in six.iteritems(entity):
             setattr(self, key, value)
 
+    def is_property(self, prop):
+        if prop in self._pull:
+            return True
+        return False
+
     def set(self, properties):
         """Set properties for object from given dict of properties.
 


### PR DESCRIPTION
Sometimes (for instance, if you're receiving user input), you need to make sure that properties are valid properties for an entity to have. Rather than using the _pull dict (which is the canonical place all properties exist) directly, wrap it in a method.

@Cawb07 FYI, will be in 1.1.1