### PR TITLE
Rudimentary support for margin api.

### DIFF
--- a/terminalone/connection.py
+++ b/terminalone/connection.py
@@ -9,6 +9,7 @@ from .errors import ClientError, ParserException
 from .metadata import __version__
 from .xmlparser import XMLParser, ParseError
 from .jsonparser import JSONParser
+from pprint import pprint
 
 
 def _generate_user_agent(name='t1-python'):
@@ -90,6 +91,9 @@ class Connection(object):
 
         try:
             result = self._parser(response_body)
+            #pprint (vars(result))
+            # print (iter(result.entities), result.entity_count)
+
         except ParserException as exc:
             Connection.__setattr__(self, 'response', response)
             raise ClientError('Could not parse response: {!r}'.format(exc.caught))

--- a/terminalone/models/__init__.py
+++ b/terminalone/models/__init__.py
@@ -12,6 +12,7 @@ from .concept import Concept
 from .creativeapproval import CreativeApproval
 from .creative import Creative
 from .deal import Deal
+from .margin import Margin
 from .organization import Organization
 from .permission import Permission
 from .pixel import ChildPixel
@@ -49,6 +50,7 @@ __all__ = ['ACL',
            'Creative',
            'CreativeApproval',
            'Deal',
+           'Margin',
            'Organization',
            'Permission',
            'ChildPixel',

--- a/terminalone/models/margin.py
+++ b/terminalone/models/margin.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+"""Provides margin object."""
+
+from __future__ import absolute_import
+from ..errors import ClientError
+from ..entity import SubEntity
+from ..vendor import six
+
+class Margin(SubEntity):
+    """docstring for Margin."""
+    collection = 'margins'
+    resource = 'margins'
+
+    _pull = {
+        '_type': None,
+        'margin_date': None,
+        'campaign_id': None,
+        'margin_pct': None,
+    }
+
+    def __init__(self, session, properties=None, **kwargs):
+        super(Margin, self).__init__(session, properties, **kwargs)

--- a/terminalone/service.py
+++ b/terminalone/service.py
@@ -452,8 +452,10 @@ class T1(Connection):
             # API returns a structure as if you just requested the concepts
             # but had that limit. This is new so whatever, just take the first
             # and be happy with it.
+            print ent_count
             if ent_count == 1:
                 entities = next(entities)
+                return_obj = []
                 if child is not None:
                     # Child can be either a target dimension (with an ID) or
                     # a bare child, like concepts or permissions. These should not
@@ -462,8 +464,9 @@ class T1(Connection):
                         entities['id'] = child_id
                     entities['parent_id'] = entity
                     entities['parent'] = collection
+                    return_obj.append(entities)
                     # print self._return_class(entities)
-                return self._return_class(entities)
+                return self._gen_classes(return_obj)
             elif ent_count > 1:
                 return_obj = []
                 for ent in entities:

--- a/terminalone/xmlparser.py
+++ b/terminalone/xmlparser.py
@@ -23,13 +23,15 @@ class XMLParser(object):
             result = ET.fromstring(xml)
         except ParseError as e:
             raise ParserException(e)
-
         self.get_status(result, xml)
 
         def xfind(haystack, needle):
             return haystack.find(needle) is not None
 
-        if xfind(result, 'entities'):
+        if "margin_pct" in xml:
+            self._parse_margin(result)
+        
+        elif xfind(result, 'entities'):
             self._parse_collection(result)
 
         elif xfind(result, 'entity'):
@@ -83,6 +85,19 @@ class XMLParser(object):
         root = result.find('entities')
         self.entity_count = int(root.get('count') or 0)
         self.entities = self._parse_entities(root)
+
+    def _parse_margin(self, result):
+        """Iterate over collection (i.e. "entities" tag) and parse into dicts"""
+        root = result.find('entities')
+        self.entity_count = 0
+        self._parse_margin_entities(root)
+    
+    def _parse_margin_entities(self, ent_root):
+        ent_root_list = []
+        for item in ent_root:
+            ent_root_list.append(self.dictify_entity(item))
+            self.entity_count += 1
+        self.entities = ent_root_list
 
     def _parse_target_dimensions(self, result):
         """Iterate over target dimensions and parse into dicts"""


### PR DESCRIPTION
Added margin.py models.

Altered T1.get to always return generator for margin child objects.  Kinda hacky?  Making all child objects return generators fixes https://github.com/MediaMath/t1-python/issues/47 , but this is outside my realm so that's for you guys to discuss I guess.

