### PR TITLE
fix generators being returned on single entities, broken unit test

### DIFF
--- a/terminalone/service.py
+++ b/terminalone/service.py
@@ -458,16 +458,8 @@ class T1(Connection):
 
         entities, ent_count = super(T1, self)._get(PATHS['mgmt'], _url, params=_params)
 
-        if entity and (child == 'permissions' or not child):
-            passed_ents = []
-            for i in six.moves.range(2):
-                try:
-                    passed_ents.append(next(entities))
-                except StopIteration:
-                    break
-            entities = chain(iter(passed_ents), entities)
-            if len(passed_ents) == 1:
-                return self._return_class(next(entities), child, child_id, entity, collection)
+        if ent_count == 1:
+            return self._return_class(next(entities), child, child_id, entity, collection)
 
         ent_gen = self._gen_classes(entities, child, child_id, entity, collection)
         if count:

--- a/tests/fixtures/advertisers_limit_1.xml
+++ b/tests/fixtures/advertisers_limit_1.xml
@@ -1,0 +1,21 @@
+<?xml version='1.0' ?>
+<result called_on="2016-03-30 13:24:59.735885+00">
+    <entities count="54190" start="0">
+        <entity name="advertiser 1" id="1" type="advertiser" version="0">
+            <prop name="agency_id" value="300"/>
+            <prop name="name" value="advertiser 1"/>
+            <prop name="vertical_id" value="12"/>
+            <prop name="ad_server_id" value="2"/>
+            <prop name="allow_x_strat_optimization" value="0"/>
+            <prop name="status" value="1"/>
+            <prop name="created_on" value="2015-08-21T15:28:53"/>
+            <prop name="updated_on" value="2015-08-21T15:28:53"/>
+            <prop name="domain" value="www.insidehook.com"/>
+            <prop name="minimize_multi_ads" value="0"/>
+            <prop name="frequency_type" value="no-limit"/>
+            <prop name="frequency_interval" value="not-applicable"/>
+            <prop name="dmp_enabled" value="inherits"/>
+        </entity>
+    </entities>
+    <status code="ok"/>
+</result>

--- a/tests/fixtures/target_dimensions.xml
+++ b/tests/fixtures/target_dimensions.xml
@@ -1,0 +1,16 @@
+<?xml version='1.0' ?>
+<result>
+    <enabled active="0" />
+    <include>
+        <entities target_op="OR">
+            <entity name="United States" id="251" type="target_value">
+                <prop name="target_dimension_id" value="7" />
+                <prop name="name" value="United States" />
+                <prop name="value" value="60231" />
+                <prop name="code" value="us" />
+                <prop name="is_targetable" value="1" />
+            </entity>
+        </entities>
+    </include>
+    <status code="ok" />
+</result>

--- a/tests/test_gets.py
+++ b/tests/test_gets.py
@@ -123,7 +123,7 @@ class TestGets(unittest.TestCase):
         self.setup()
         with open('tests/fixtures/advertisers.xml') as f:
             advertisers = f.read()
-        with open('tests/fixtures/advertiser.xml') as f:
+        with open('tests/fixtures/advertisers_limit_1.xml') as f:
             advertiser = f.read()
         responses.add(responses.GET,
                       'https://api.mediamath.com/api/v2.0/advertisers?page_limit=1&page_offset=0&sort_by=id',
@@ -304,5 +304,16 @@ class TestGets(unittest.TestCase):
         r = self.t1.new('report')
         md = r.metadata
         assert hasattr(md, 'keys'), 'Expected mapping structure, got: %r' % type(md)
-
         assert 'reports' in md, 'Expected overall metadata, got: %r' % md
+
+    @responses.activate
+    def test_target_dimensions(self):
+        self.setup()
+        with open('tests/fixtures/target_dimensions.xml') as f:
+            fixture = f.read()
+        responses.add(responses.GET,
+                      'https://api.mediamath.com/api/v2.0/strategies/151940/target_dimensions/7',
+                      body=fixture,
+                      content_type='application/xml')
+        t = self.t1.get('strategies', 151940, child='region')
+        assert t._type == 'target_dimension', 'Expected target_dimension entity, got: %r' % t


### PR DESCRIPTION
This slipped past code review; I'm not sure why the code to handle the special case for permissions was so complex, and it seems checking the ent_count is enough.

In any case, the existing code broke target_dimensions and so the acceptance test script was failing. 

This also fixes a broken/faulty unit test that was using an incorrect fixture.