### PR TITLE
move conversion functions into new module; throw more informative errors

### DIFF
--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -2,7 +2,6 @@
 """Provides base object for T1 data classes."""
 
 from __future__ import absolute_import, division
-
 from warnings import warn
 from .config import PATHS
 from .connection import Connection

--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -2,12 +2,11 @@
 """Provides base object for T1 data classes."""
 
 from __future__ import absolute_import, division
-from datetime import datetime, timedelta
+
 from warnings import warn
 from .config import PATHS
 from .connection import Connection
 from .errors import ClientError
-from terminalone.utils import FixedOffset
 from .vendor import six
 
 
@@ -81,7 +80,14 @@ class Entity(Connection):
 
     def __setattr__(self, attribute, value):
         if self._pull.get(attribute) is not None:
-            self.properties[attribute] = self._pull[attribute](value)
+            try:
+                self.properties[attribute] = self._pull[attribute](value)
+            except ValueError:
+                raise ClientError('key {} is invalid: must be of type {}'
+                                  .format(attribute, self._pull[attribute]))
+            except TypeError as e:
+                raise ClientError('key {} is invalid: {}'
+                                  .format(attribute, e.message))
         else:
             self.properties[attribute] = value
 
@@ -98,85 +104,6 @@ class Entity(Connection):
     def __setstate__(self, state):
         """Custom unpickling. TODO"""
         return super(Entity, self).__setstate__(state)
-
-    @staticmethod
-    def _int_to_bool(value):
-        """Convert integer string {"0","1"} to its corresponding bool"""
-        return bool(int(value))
-
-    @staticmethod
-    def _none_to_empty(val):
-        """Convert None to empty string.
-
-        Necessary for fields that are required POST but have no logical value.
-        """
-        if val is None:
-            return ""
-        return val
-
-    @staticmethod
-    def _enum(all_vars, default):
-        """Check input against accepted set or return a default."""
-
-        def get_value(test_value):
-            if test_value in all_vars:
-                return test_value
-            else:
-                return default
-
-        return get_value
-
-    @staticmethod
-    def _default_empty(default):
-        """Check an input against its falsy value or return a default."""
-
-        def get_value(test_value):
-            if test_value:
-                return test_value
-            else:
-                return default
-
-        return get_value
-
-    @staticmethod
-    def _strpt(dt_string):
-        """Convert ISO string time to datetime.datetime. No-op on datetimes"""
-        if isinstance(dt_string, datetime):
-            return dt_string
-        if dt_string[-5] == '-' or dt_string[-5] == '+':
-            offset_str = dt_string[-5:]
-            dt_string = dt_string[:-5]
-            offset = int(offset_str[-4:-2]) * 60 + int(offset_str[-2:])
-            if offset_str[0] == "-":
-                offset = -offset
-        else:
-            offset = 0
-
-        return datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=FixedOffset(offset))
-
-    @staticmethod
-    def _strft(dt_obj, null_on_none=False):
-        """Convert datetime.datetime to ISO string.
-
-        :param null_on_none: bool Occasionally, we will actually want to send an
-            empty string where a datetime would typically go. For instance, if a
-            strategy has an end_date set, but then wants to change to use
-            campaign end date, the POST will normally omit the end_date field
-            (because you cannot send it with use_campaign_end).
-            However, this will cause an error because there was an end_date set
-            previously. So, we need to send an empty string to indicate that it
-            should be nulled out. In cases like this, null_on_none should be set
-            to True in the entity's _push dict using a partial to make it a
-            single-argument function. See strategy.py
-        :raise AttributeError: if not provided a datetime
-        :return: str
-        """
-        try:
-            return dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
-        except AttributeError:
-            if dt_obj is None and null_on_none:
-                return ""
-            raise
 
     def _validate_read(self, data):
         """Convert XML strings to Python objects"""
@@ -213,7 +140,14 @@ class Entity(Connection):
                 continue
 
             if push_fn is not None:
-                data[key] = self._push[key](value)
+                try:
+                    data[key] = self._push[key](value)
+                except ValueError:
+                    raise ClientError('key {} is invalid: must be of type {}'
+                                      .format(key, self._push[key]))
+                except TypeError as e:
+                    raise ClientError('key {} is invalid: {}'
+                                      .format(key, e.message))
             else:
                 data[key] = value
         return data

--- a/terminalone/models/advertiser.py
+++ b/terminalone/models/advertiser.py
@@ -2,7 +2,7 @@
 """Provides advertiser object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/advertiser.py
+++ b/terminalone/models/advertiser.py
@@ -2,6 +2,7 @@
 """Provides advertiser object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -9,10 +10,10 @@ class Advertiser(Entity):
     """Advertiser entity."""
     collection = 'advertisers'
     resource = 'advertiser'
-    _dmp_settings = Entity._enum({'disabled', 'inherits'}, 'inherits')
-    _freq_int = Entity._enum({'hour', 'day', 'week', 'month', 'campaign',
+    _dmp_settings = t1types.enum({'disabled', 'inherits'}, 'inherits')
+    _freq_int = t1types.enum({'hour', 'day', 'week', 'month', 'campaign',
                               'not-applicable'}, 'not-applicable')
-    _freq_type = Entity._enum({'even', 'asap', 'no-limit'}, 'no-limit')
+    _freq_type = t1types.enum({'even', 'asap', 'no-limit'}, 'no-limit')
     _relations = {
         'ad_server', 'agency', 'billing_contact', 'sales_contact', 'vertical',
     }
@@ -22,20 +23,20 @@ class Advertiser(Entity):
         'ad_server_password': None,
         'ad_server_username': None,
         'agency_id': int,
-        'allow_x_strat_optimization': Entity._int_to_bool,
+        'allow_x_strat_optimization': t1types.int_to_bool,
         'billing_contact_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'domain': None,
         'dmp_enabled': None,
         'frequency_amount': int,
         'frequency_interval': None,
         'frequency_type': None,
         'id': int,
-        'minimize_multi_ads': Entity._int_to_bool,
+        'minimize_multi_ads': t1types.int_to_bool,
         'name': None,
         'sales_contact_id': int,
-        'status': Entity._int_to_bool,
-        'updated_on': Entity._strpt,
+        'status': t1types.int_to_bool,
+        'updated_on': t1types.strpt,
         'version': int,
         'vertical_id': int,
     }

--- a/terminalone/models/agency.py
+++ b/terminalone/models/agency.py
@@ -2,7 +2,7 @@
 """Provides agency object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/agency.py
+++ b/terminalone/models/agency.py
@@ -2,6 +2,7 @@
 """Provides agency object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -13,21 +14,21 @@ class Agency(Entity):
         'organization', 'billing_contact', 'sales_contact',
         'traffic_contact',
     }
-    _dmp_settings = Entity._enum({'disabled', 'inherits'}, 'inherits')
+    _dmp_settings = t1types.enum({'disabled', 'inherits'}, 'inherits')
     _pull = {
-        'allow_x_adv_optimization': Entity._int_to_bool,
-        'allow_x_adv_pixels': Entity._int_to_bool,
+        'allow_x_adv_optimization': t1types.int_to_bool,
+        'allow_x_adv_pixels': t1types.int_to_bool,
         'billing_contact_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'dmp_enabled': None,
         'id': int,
         'logo': None,
         'name': None,
         'organization_id': int,
         'sales_contact_id': int,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'traffic_contact_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/atomiccreative.py
+++ b/terminalone/models/atomiccreative.py
@@ -2,7 +2,7 @@
 """Provides Atomic Creative object for working with creatives."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/atomiccreative.py
+++ b/terminalone/models/atomiccreative.py
@@ -2,6 +2,7 @@
 """Provides Atomic Creative object for working with creatives."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,19 +13,19 @@ class AtomicCreative(Entity):
     _relations = {
         'advertiser', 'concept', 'creative_approvals', 'creatives',
     }
-    _ad_formats = Entity._enum({'DISPLAY', 'EXPANDABLE', 'MOBILE'},
+    _ad_formats = t1types.enum({'DISPLAY', 'EXPANDABLE', 'MOBILE'},
                                'DISPLAY')
-    _ad_servers = Entity._enum({'ATLAS', 'DART', 'EYEWONDER', 'MEDIAMIND',
+    _ad_servers = t1types.enum({'ATLAS', 'DART', 'EYEWONDER', 'MEDIAMIND',
                                 'MEDIAPLEX', 'POINTROLL', 'YIELD_MANAGER',
                                 'TERMINALONE', 'MEDIAFORGE', 'OTHER'},
                                'OTHER')
-    _expands = Entity._enum({'L', 'R', 'U', 'D', 'LD', 'RD', 'LU', 'RU'}, None)
-    _expand_dir = Entity._default_empty('NONRESTRICTED')
-    _expand_trig = Entity._enum({'AUTOMATIC', 'MOUSEOVER', 'CLICK'}, 'CLICK')
-    _file_types = Entity._enum({'swf', 'gif', 'html5', 'jpg', 'jpeg', 'tif',
+    _expands = t1types.enum({'L', 'R', 'U', 'D', 'LD', 'RD', 'LU', 'RU'}, None)
+    _expand_dir = t1types.default_empty('NONRESTRICTED')
+    _expand_trig = t1types.enum({'AUTOMATIC', 'MOUSEOVER', 'CLICK'}, 'CLICK')
+    _file_types = t1types.enum({'swf', 'gif', 'html5', 'jpg', 'jpeg', 'tif',
                                 'tiff', 'png', 'unknown', 'vast'}, 'unknown')
-    _media_types = Entity._enum({'display', 'video', 'mobile'}, 'display')
-    _tag_types = Entity._enum({'IFRAME_SCRIPT_NOSCRIPT', 'IFRAME_SCRIPT',
+    _media_types = t1types.enum({'display', 'video', 'mobile'}, 'display')
+    _tag_types = t1types.enum({'IFRAME_SCRIPT_NOSCRIPT', 'IFRAME_SCRIPT',
                                'IFRAME_NOSCRIPT', 'IFRAME_IMG',
                                'SCRIPT_NOSCRIPT', 'SCRIPT', 'NOSCRIPT',
                                'IFRAME', 'IMG'}, 'NOSCRIPT')
@@ -33,42 +34,42 @@ class AtomicCreative(Entity):
         'ad_format': None,
         'ad_server_type': None,
         'approval_status': None,
-        'build_date': Entity._strpt,
+        'build_date': t1types.strpt,
         'build_errors': None,
-        'built': Entity._int_to_bool,
+        'built': t1types.int_to_bool,
         'built_by_user_id': int,
         'click_through_url': None,
         'click_url': None,
         'concept_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'creative_import_file_id': int,
         'edited_tag': None,
-        'end_date': Entity._strpt,
+        'end_date': t1types.strpt,
         'expand': None,
         'expansion_direction': None,
         'expansion_trigger': None,
         'external_identifier': None,
         'file_type': None,
-        'has_sound': Entity._int_to_bool,
+        'has_sound': t1types.int_to_bool,
         'height': int,
         'id': int,
-        'is_https': Entity._int_to_bool,
-        'is_multi_creative': Entity._int_to_bool,
-        'last_modified': Entity._strpt,
+        'is_https': t1types.int_to_bool,
+        'is_multi_creative': t1types.int_to_bool,
+        'last_modified': t1types.strpt,
         'media_type': None,
         'name': None,
         'rejected_reason': None,
-        'rich_media': Entity._int_to_bool,
+        'rich_media': t1types.int_to_bool,
         'rich_media_provider': None,
-        'start_date': Entity._strpt,
-        'status': Entity._int_to_bool,
-        't1as': Entity._int_to_bool,
+        'start_date': t1types.strpt,
+        'status': t1types.int_to_bool,
+        't1as': t1types.int_to_bool,
         'tag': None,
         'tag_type': None,
         'tpas_ad_tag': None,
         'tpas_ad_tag_name': None,
         'type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
         'width': int,
     }
@@ -76,7 +77,7 @@ class AtomicCreative(Entity):
     _push.update({
         'ad_format': _ad_formats,
         'ad_server_type': _ad_servers,
-        'end_date': Entity._strft,
+        'end_date': t1types.strft,
         'expand': _expands,
         'expansion_direction': _expand_dir,
         'expansion_trigger': _expand_trig,
@@ -86,7 +87,7 @@ class AtomicCreative(Entity):
         'is_multi_creative': int,
         'media_type': _media_types,
         'rich_media': int,
-        'start_date': Entity._strft,
+        'start_date': t1types.strft,
         'status': int,
         't1as': int,
         'tag_type': _tag_types,

--- a/terminalone/models/audiencesegment.py
+++ b/terminalone/models/audiencesegment.py
@@ -2,6 +2,7 @@
 """Provides audience segment object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -15,10 +16,10 @@ class AudienceSegment(Entity):
     }
     _pull = {
         'audience_vendor_id': int,
-        'buyable': Entity._int_to_bool,
+        'buyable': t1types.int_to_bool,
         'child_count': int,
         'code': None,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'full_path': None,
         'id': int,
         'name': None,
@@ -27,7 +28,7 @@ class AudienceSegment(Entity):
         'wholesale_cpm': float,
         'tag': None,
         'uniques': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
 

--- a/terminalone/models/audiencesegment.py
+++ b/terminalone/models/audiencesegment.py
@@ -2,7 +2,7 @@
 """Provides audience segment object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/campaign.py
+++ b/terminalone/models/campaign.py
@@ -2,6 +2,7 @@
 """Provides campaign object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -16,14 +17,14 @@ class Campaign(Entity):
     _relations = {
         'advertiser', 'ad_server', 'currency', 'merit_pixel', 'time_zone',
     }
-    _conv = Entity._enum({'every', 'one', 'variable'}, 'variable')
-    _freq_ints = Entity._enum({'hour', 'day', 'week', 'month',
+    _conv = t1types.enum({'every', 'one', 'variable'}, 'variable')
+    _freq_ints = t1types.enum({'hour', 'day', 'week', 'month',
                                'not-applicable'}, 'not-applicable')
-    _freq_types = Entity._enum({'even', 'asap', 'no-limit'}, 'no-limit')
-    _goal_cats = Entity._enum({'audience', 'engagement', 'response'}, None)
-    _goal_types = Entity._enum({'spend', 'reach', 'cpc', 'cpe', 'cpa', 'roi'},
+    _freq_types = t1types.enum({'even', 'asap', 'no-limit'}, 'no-limit')
+    _goal_cats = t1types.enum({'audience', 'engagement', 'response'}, None)
+    _goal_types = t1types.enum({'spend', 'reach', 'cpc', 'cpe', 'cpa', 'roi'},
                                None)
-    _serv_types = Entity._enum({'SELF', 'MANAGED'}, 'SELF')
+    _serv_types = t1types.enum({'SELF', 'MANAGED'}, 'SELF')
     _pull = {
         'ad_server_fee': float,
         'ad_server_id': int,
@@ -33,10 +34,10 @@ class Campaign(Entity):
         'agency_fee_pct': float,
         'conversion_type': None,
         'conversion_variable_minutes': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'currency_code': None,
-        'dcs_data_is_campaign_level': Entity._int_to_bool,
-        'end_date': Entity._strpt,
+        'dcs_data_is_campaign_level': t1types.int_to_bool,
+        'end_date': t1types.strpt,
         'frequency_amount': int,
         'frequency_interval': None,
         'frequency_type': None,
@@ -44,11 +45,11 @@ class Campaign(Entity):
         'goal_category': None,
         'goal_type': None,
         'goal_value': float,
-        'has_custom_attribution': Entity._int_to_bool,
+        'has_custom_attribution': t1types.int_to_bool,
         'id': int,
         'io_name': None,
         'io_reference_num': None,
-        'initial_start_date': Entity._strpt,
+        'initial_start_date': t1types.strpt,
         'margin_pct': float,
         'merit_pixel_id': int,
         'name': None,
@@ -58,14 +59,14 @@ class Campaign(Entity):
         'pv_window_minutes': int,
         'service_type': None,
         'spend_cap_amount': float,
-        'spend_cap_automatic': Entity._int_to_bool,
-        'spend_cap_enabled': Entity._int_to_bool,
-        'start_date': Entity._strpt,
-        'status': Entity._int_to_bool,
+        'spend_cap_automatic': t1types.int_to_bool,
+        'spend_cap_enabled': t1types.int_to_bool,
+        'start_date': t1types.strpt,
+        'status': t1types.int_to_bool,
         'total_budget': float,
-        'updated_on': Entity._strpt,
-        'use_default_ad_server': Entity._int_to_bool,
-        'use_mm_freq': Entity._int_to_bool,
+        'updated_on': t1types.strpt,
+        'use_default_ad_server': t1types.int_to_bool,
+        'use_mm_freq': t1types.int_to_bool,
         'version': int,
         'zone_name': None,
     }
@@ -73,17 +74,17 @@ class Campaign(Entity):
     _push.update({
         'conversion_type': _conv,
         'dcs_data_is_campaign_level': int,
-        'end_date': Entity._strft,
+        'end_date': t1types.strft,
         'frequency_interval': _freq_ints,
         'frequency_type': _freq_types,
         'goal_category': _goal_cats,
         'goal_type': _goal_types,
         'has_custom_attribution': int,
-        'initial_start_date': Entity._strft,
+        'initial_start_date': t1types.strft,
         'service_type': _serv_types,
         'spend_cap_automatic': int,
         'spend_cap_enabled': int,
-        'start_date': Entity._strft,
+        'start_date': t1types.strft,
         'status': int,
         'use_default_ad_server': int,
         'use_mm_freq': int,

--- a/terminalone/models/campaign.py
+++ b/terminalone/models/campaign.py
@@ -2,7 +2,7 @@
 """Provides campaign object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/concept.py
+++ b/terminalone/models/concept.py
@@ -2,6 +2,7 @@
 """Provides concept object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -14,11 +15,11 @@ class Concept(Entity):
     }
     _pull = {
         'advertiser_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
         'name': None,
-        'status': Entity._int_to_bool,
-        'updated_on': Entity._strpt,
+        'status': t1types.int_to_bool,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/concept.py
+++ b/terminalone/models/concept.py
@@ -2,7 +2,7 @@
 """Provides concept object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/creative.py
+++ b/terminalone/models/creative.py
@@ -2,6 +2,7 @@
 """Provides creative object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -21,9 +22,9 @@ class Creative(Entity):
     }
     _pull = {
         'atomic_creative_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
-        'last_modified': Entity._strpt,
+        'last_modified': t1types.strpt,
         'tag': None,
         'tag_type': None,
         'version': int,

--- a/terminalone/models/creative.py
+++ b/terminalone/models/creative.py
@@ -2,7 +2,7 @@
 """Provides creative object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/creativeapproval.py
+++ b/terminalone/models/creativeapproval.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from terminalone import t1types
+from .. import t1types
 from ..errors import ClientError
 from ..entity import Entity
 

--- a/terminalone/models/creativeapproval.py
+++ b/terminalone/models/creativeapproval.py
@@ -2,6 +2,8 @@
 """Provides Creative Approval object for working with creatives."""
 
 from __future__ import absolute_import
+
+from terminalone import t1types
 from ..errors import ClientError
 from ..entity import Entity
 
@@ -14,13 +16,13 @@ class CreativeApproval(Entity):
         'additional_detail': None,
         'approval_status': None,
         'atomic_creative_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'creative_import_file_id': int,
         'external_identifier': None,
         'id': int,
         'rejected_reason': None,
         'supply_source_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
 

--- a/terminalone/models/creativeapproval.py
+++ b/terminalone/models/creativeapproval.py
@@ -2,7 +2,6 @@
 """Provides Creative Approval object for working with creatives."""
 
 from __future__ import absolute_import
-
 from .. import t1types
 from ..errors import ClientError
 from ..entity import Entity

--- a/terminalone/models/deal.py
+++ b/terminalone/models/deal.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/deal.py
+++ b/terminalone/models/deal.py
@@ -2,6 +2,8 @@
 """Provides deal object for PMP-E and Global Deals."""
 
 from __future__ import absolute_import
+
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -14,42 +16,42 @@ class Deal(Entity):
         'publisher',
         'supply_source',
     }
-    _deal_sources = Entity._enum({'USER', 'INTERNAL'}, 'INTERNAL')
-    _media_types = Entity._enum({'DISPLAY', 'VIDEO'}, 'DISPLAY')
-    _price_methods = Entity._enum({'CPM'}, 'CPM')
-    _price_types = Entity._enum({'FIXED', 'FLOOR'}, None)
+    _deal_sources = t1types.enum({'USER', 'INTERNAL'}, 'INTERNAL')
+    _media_types = t1types.enum({'DISPLAY', 'VIDEO'}, 'DISPLAY')
+    _price_methods = t1types.enum({'CPM'}, 'CPM')
+    _price_types = t1types.enum({'FIXED', 'FLOOR'}, None)
     _pull = {
         'advertiser_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'currency_code': None,
         'deal_identifier': None,
         'deal_source': None,
         'description': None,
-        'end_datetime': Entity._strpt,
+        'end_datetime': t1types.strpt,
         'id': int,
         'media_type': None,
         'name': None,
-        'partner_sourced': Entity._int_to_bool,
+        'partner_sourced': t1types.int_to_bool,
         'price': float,
         'price_method': None,
         'price_type': None,
         'publisher_id': int,
-        'start_datetime': Entity._strpt,
-        'status': Entity._int_to_bool,
+        'start_datetime': t1types.strpt,
+        'status': t1types.int_to_bool,
         'supply_source_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
         'zone_name': None,
     }
     _push = _pull.copy()
     _push.update({
         'deal_source': _deal_sources,
-        'end_datetime': Entity._strft,
+        'end_datetime': t1types.strft,
         'media_type': _media_types,
         'partner_sourced': int,
         'price_method': _price_methods,
         'price_type': _price_types,
-        'start_datetime': Entity._strft,
+        'start_datetime': t1types.strft,
         'status': int,
     })
 

--- a/terminalone/models/deal.py
+++ b/terminalone/models/deal.py
@@ -2,7 +2,6 @@
 """Provides deal object for PMP-E and Global Deals."""
 
 from __future__ import absolute_import
-
 from .. import t1types
 from ..entity import Entity
 

--- a/terminalone/models/organization.py
+++ b/terminalone/models/organization.py
@@ -2,6 +2,7 @@
 """Provides agency object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -13,33 +14,33 @@ class Organization(Entity):
         'currency',
         'seats',
     }
-    _dmp_settings = Entity._enum({'disabled', 'enabled'}, 'disabled')
-    _org_types = Entity._enum({'buyer', 'partner'}, 'buyer')
+    _dmp_settings = t1types.enum({'disabled', 'enabled'}, 'disabled')
+    _org_types = t1types.enum({'buyer', 'partner'}, 'buyer')
     _pull = {
         'address_1': None,
         'address_2': None,
         'adx_seat_account_id': int,
-        'allow_byo_price': Entity._int_to_bool,
-        'allow_x_agency_pixels': Entity._int_to_bool,
+        'allow_byo_price': t1types.int_to_bool,
+        'allow_x_agency_pixels': t1types.int_to_bool,
         'billing_country_code': None,
         'city': None,
         'contact_name': None,
         'country': None,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'curency_code': None,
         'dmp_enabled': None,
         'id': int,
         'mm_contact_name': None,
         'name': None,
         'org_type': None,
-        'override_suspicious_traffic_filter': Entity._int_to_bool,
+        'override_suspicious_traffic_filter': t1types.int_to_bool,
         'phone': None,
         'state': None,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'suspicious_traffic_filter_level': int,
         'tag_ruleset': None,
-        'updated_on': Entity._strpt,
-        'use_evidon_optout': Entity._int_to_bool,
+        'updated_on': t1types.strpt,
+        'use_evidon_optout': t1types.int_to_bool,
         'version': int,
         'zip': None,
     }

--- a/terminalone/models/organization.py
+++ b/terminalone/models/organization.py
@@ -2,7 +2,7 @@
 """Provides agency object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/pixel.py
+++ b/terminalone/models/pixel.py
@@ -2,6 +2,7 @@
 """Provides child pixel object. This is *distinct* from PixelBundle; please see the documentation"""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,16 +13,16 @@ class ChildPixel(Entity):
     _relations = {
         'pixel_bundle',
     }
-    _pixel_types = Entity._enum({'creative', 'event', 'data'}, None)
+    _pixel_types = t1types.enum({'creative', 'event', 'data'}, None)
     _pull = {
         'bundle_id': int,
-        'created_on': Entity._strpt,
-        'distributed': Entity._int_to_bool,
+        'created_on': t1types.strpt,
+        'distributed': t1types.int_to_bool,
         'id': int,
         'pixel_type': None,
         'supply_source_id': int,
         'tag': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/pixel.py
+++ b/terminalone/models/pixel.py
@@ -2,7 +2,7 @@
 """Provides child pixel object. This is *distinct* from PixelBundle; please see the documentation"""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/pixelbundle.py
+++ b/terminalone/models/pixelbundle.py
@@ -2,6 +2,7 @@
 """Provides Pixel Bundle object for working with T1 pixels."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,12 +13,12 @@ class Pixel(Entity):
     _relations = {
         'advertiser', 'agency', 'provider',
     }
-    _roi_fields = Entity._enum({'S1', 'S2', 'V1', 'V2'}, None)
-    _pixel_types = Entity._enum({'creative', 'event', 'data', 'segment'},
+    _roi_fields = t1types.enum({'S1', 'S2', 'V1', 'V2'}, None)
+    _pixel_types = t1types.enum({'creative', 'event', 'data', 'segment'},
                                 'event')
-    _pricing = Entity._enum({'CPM', 'CPTS'}, 'CPM')
-    _rmx_conv_types = Entity._enum({'one', 'variable'}, 'one')
-    _tag_types = Entity._enum({'dfa', 'uat', 'image', 'iframe', 'js'},
+    _pricing = t1types.enum({'CPM', 'CPTS'}, 'CPM')
+    _rmx_conv_types = t1types.enum({'one', 'variable'}, 'one')
+    _tag_types = t1types.enum({'dfa', 'uat', 'image', 'iframe', 'js'},
                               'image')
     _pull = {
         'advertiser_id': int,
@@ -25,10 +26,10 @@ class Pixel(Entity):
         'cost_cpm': float,
         'cost_cpts': float,
         'cost_pct_cpm': float,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'currency': None,
         'currency_fixed': None,
-        'eligible': Entity._int_to_bool,
+        'eligible': t1types.int_to_bool,
         'external_identifier': None,
         'id': int,
         'keywords': None,
@@ -39,23 +40,23 @@ class Pixel(Entity):
         'revenue': None,
         'rmx_conversion_minutes': int,
         'rmx_conversion_type': None,
-        'rmx_friendly': Entity._int_to_bool,
-        'rmx_merit': Entity._int_to_bool,
+        'rmx_friendly': t1types.int_to_bool,
+        'rmx_merit': t1types.int_to_bool,
         'rmx_pc_window_minutes': int,
         'rmx_pv_window_minutes': int,
         'segment_op': None,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'tag_type': None,
         'tags': None,
         'type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
 
     _push = _pull.copy()
     _push.update({
-        'cost_cpm': Entity._none_to_empty,
-        'cost_pct_cpm': Entity._none_to_empty,
+        'cost_cpm': t1types.none_to_empty,
+        'cost_pct_cpm': t1types.none_to_empty,
         'currency': _roi_fields,
         'eligible': int,
         'pixel_type': _pixel_types,

--- a/terminalone/models/pixelbundle.py
+++ b/terminalone/models/pixelbundle.py
@@ -2,7 +2,7 @@
 """Provides Pixel Bundle object for working with T1 pixels."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/pixelprovider.py
+++ b/terminalone/models/pixelprovider.py
@@ -2,7 +2,7 @@
 """Provides pixel provider object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/pixelprovider.py
+++ b/terminalone/models/pixelprovider.py
@@ -2,6 +2,7 @@
 """Provides pixel provider object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -9,20 +10,20 @@ class PixelProvider(Entity):
     """docstring for pixel provider."""
     collection = 'pixel_providers'
     resource = 'pixel_provider'
-    _executors = Entity._enum({'MEDIAMATH', 'UDI'}, 'UDI')
+    _executors = t1types.enum({'MEDIAMATH', 'UDI'}, 'UDI')
     _relations = {
         'agency',
         'vendor',
     }
     _pull = {
         'agency_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'execution_by': None,
         'id': int,
         'name': None,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'taxonomy_file': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'vendor_id': int,
         'version': int,
     }

--- a/terminalone/models/placementslot.py
+++ b/terminalone/models/placementslot.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 from datetime import datetime
-
 from .. import t1types
 from ..entity import Entity
 from ..vendor import six

--- a/terminalone/models/placementslot.py
+++ b/terminalone/models/placementslot.py
@@ -3,6 +3,8 @@
 
 from __future__ import absolute_import
 from datetime import datetime
+
+from terminalone import t1types
 from ..entity import Entity
 from ..vendor import six
 
@@ -36,24 +38,24 @@ class PlacementSlot(Entity):
         'start_date': datetime(2012, 10, 1, 0, 0, 0),
         'volume_unit': 'impressions',
     }
-    _auction_types = Entity._enum({'FIRST_PRICED', 'SECOND_PRICED'},
+    _auction_types = t1types.enum({'FIRST_PRICED', 'SECOND_PRICED'},
                                   'FIRST_PRICED')
-    _price_types = Entity._enum({'CPM', }, 'CPM')
-    _frequency_intervals = Entity._enum({'hour', 'day', 'week', 'month',
+    _price_types = t1types.enum({'CPM', }, 'CPM')
+    _frequency_intervals = t1types.enum({'hour', 'day', 'week', 'month',
                                          'campaign', 'not-applicable'},
                                         'not-applicable')
-    _frequency_types = Entity._enum({'even', 'asap', 'no-limit'}, 'no-limit')
-    _volume_units = Entity._enum({'impressions', }, 'impressions')
+    _frequency_types = t1types.enum({'even', 'asap', 'no-limit'}, 'no-limit')
+    _volume_units = t1types.enum({'impressions', }, 'impressions')
     _pull = {
         'ad_slot': int,
-        'allow_remnant': Entity._int_to_bool,
+        'allow_remnant': t1types.int_to_bool,
         'auction_type': None,
         'budget': float,
         'buy_price': float,
         'buy_price_type': None,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'description': None,
-        'end_date': Entity._strpt,
+        'end_date': t1types.strpt,
         'est_volume': float,
         'frequency_amount': int,
         'frequency_interval': None,
@@ -65,8 +67,8 @@ class PlacementSlot(Entity):
         'sell_price': float,
         'sell_price_type': None,
         'site_placement_id': int,
-        'start_date': Entity._strpt,
-        'updated_on': Entity._strpt,
+        'start_date': t1types.strpt,
+        'updated_on': t1types.strpt,
         'version': int,
         'volume_unit': None,
         'width': int,

--- a/terminalone/models/placementslot.py
+++ b/terminalone/models/placementslot.py
@@ -4,7 +4,7 @@
 from __future__ import absolute_import
 from datetime import datetime
 
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 from ..vendor import six
 

--- a/terminalone/models/publisher.py
+++ b/terminalone/models/publisher.py
@@ -2,6 +2,7 @@
 """Provides publisher object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -15,11 +16,11 @@ class Publisher(Entity):
         'site',
     }
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
         'name': None,
         'organization_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull

--- a/terminalone/models/publisher.py
+++ b/terminalone/models/publisher.py
@@ -2,7 +2,7 @@
 """Provides publisher object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/publishersite.py
+++ b/terminalone/models/publishersite.py
@@ -2,6 +2,7 @@
 """Provides publisher_site object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -14,11 +15,11 @@ class PublisherSite(Entity):
         'placement',
     }
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
         'name': None,
         'publisher_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull

--- a/terminalone/models/publishersite.py
+++ b/terminalone/models/publishersite.py
@@ -2,7 +2,7 @@
 """Provides publisher_site object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/rmxstrategy.py
+++ b/terminalone/models/rmxstrategy.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 from warnings import warn
+from terminalone import t1types
 from ..entity import Entity
 from ..errors import ClientError
 
@@ -19,7 +20,7 @@ class RMXStrategy(Entity):
         'budget_type': None,
         'cpa_pixel_bundle_id': int,
         'cpa_pixel_type': None,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'dynamic_pricing_option': None,
         'id': int,
         'imp_budget': float,
@@ -37,9 +38,9 @@ class RMXStrategy(Entity):
         'roi_cpc_target_ctr_type': None,
         'roi_modifier': float,
         'roi_targets': None,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'strategy_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
 

--- a/terminalone/models/rmxstrategy.py
+++ b/terminalone/models/rmxstrategy.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 from warnings import warn
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 from ..errors import ClientError
 

--- a/terminalone/models/rmxstrategyroitargetpixel.py
+++ b/terminalone/models/rmxstrategyroitargetpixel.py
@@ -5,6 +5,7 @@ DEPRECATED: new entities should not be made.
 
 from __future__ import absolute_import
 from warnings import warn
+from terminalone import t1types
 from ..entity import Entity
 from ..errors import ClientError
 
@@ -19,14 +20,14 @@ class RMXStrategyROITargetPixel(Entity):
         'pixel_bundle', 'rmx_strategy'
     }
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
         'pixel_bundle_id': int,
         'price': float,
         'rmx_pixel_type': None,
         'rmx_strategy_id': int,
-        'status': Entity._int_to_bool,
-        'updated_on': Entity._strpt,
+        'status': t1types.int_to_bool,
+        'updated_on': t1types.strpt,
         'version': int,
     }
 

--- a/terminalone/models/rmxstrategyroitargetpixel.py
+++ b/terminalone/models/rmxstrategyroitargetpixel.py
@@ -5,7 +5,7 @@ DEPRECATED: new entities should not be made.
 
 from __future__ import absolute_import
 from warnings import warn
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 from ..errors import ClientError
 

--- a/terminalone/models/seat.py
+++ b/terminalone/models/seat.py
@@ -2,7 +2,7 @@
 """Provides seat object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/seat.py
+++ b/terminalone/models/seat.py
@@ -2,6 +2,7 @@
 """Provides seat object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,19 +13,19 @@ class Seat(Entity):
     _relations = {
         'advertiser',
     }
-    _rmx_units = Entity._enum({'CPM', 'PCT_MEDIA'}, 'PCT_MEDIA')
+    _rmx_units = t1types.enum({'CPM', 'PCT_MEDIA'}, 'PCT_MEDIA')
     _pull = {
-        'bill_media_to_client': Entity._int_to_bool,
-        'created_on': Entity._strpt,
+        'bill_media_to_client': t1types.int_to_bool,
+        'created_on': t1types.strpt,
         'id': int,
         'organization_id': int,
         'rmx_exchange_cost_cpm': float,
         'rmx_exchange_cost_pct': float,
         'rmx_exchange_cost_unit': None,
         'seat_identifier': None,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'supply_source_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/sitelist.py
+++ b/terminalone/models/sitelist.py
@@ -2,7 +2,7 @@
 """Provides site list object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/sitelist.py
+++ b/terminalone/models/sitelist.py
@@ -2,6 +2,7 @@
 """Provides site list object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,16 +13,16 @@ class SiteList(Entity):
     _relations = {
         'organization',
     }
-    _restrictions = Entity._enum({'INCLUDE', 'EXCLUDE'}, 'EXCLUDE')
+    _restrictions = t1types.enum({'INCLUDE', 'EXCLUDE'}, 'EXCLUDE')
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'filename': None,
         'id': int,
         'name': None,
         'organization_id': int,
         'restriction': None,
-        'status': Entity._int_to_bool,
-        'updated_on': Entity._strpt,
+        'status': t1types.int_to_bool,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/siteplacement.py
+++ b/terminalone/models/siteplacement.py
@@ -2,7 +2,7 @@
 """Provides site_placement object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/siteplacement.py
+++ b/terminalone/models/siteplacement.py
@@ -2,6 +2,7 @@
 """Provides site_placement object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -13,12 +14,12 @@ class SitePlacement(Entity):
         'publisher',
         'placement',
     }
-    _deal_sources = Entity._enum({'USER', 'INTERNAL'}, 'USER')
-    _media_types = Entity._enum({'display', 'video', 'mobile'}, 'display')
-    _pmp_types = Entity._enum({'DIRECT', 'PREMIUM'}, 'DIRECT')
+    _deal_sources = t1types.enum({'USER', 'INTERNAL'}, 'USER')
+    _media_types = t1types.enum({'display', 'video', 'mobile'}, 'display')
+    _pmp_types = t1types.enum({'DIRECT', 'PREMIUM'}, 'DIRECT')
     _pull = {
-        'bill_media_to_client': Entity._int_to_bool,
-        'created_on': Entity._strpt,
+        'bill_media_to_client': t1types.int_to_bool,
+        'created_on': t1types.strpt,
         'deal_source': None,
         'display_text': None,
         'id': int,
@@ -26,7 +27,7 @@ class SitePlacement(Entity):
         'name': None,
         'pmp_type': None,
         'publisher_site_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 from functools import partial
 import re
-
 from .. import t1types
 from ..config import PATHS
 from ..entity import Entity

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -4,6 +4,8 @@
 from __future__ import absolute_import
 from functools import partial
 import re
+
+from terminalone import t1types
 from ..config import PATHS
 from ..entity import Entity
 from ..utils import suppress
@@ -19,31 +21,31 @@ class Strategy(Entity):
     _relations = {
         'campaign', 'currency', 'time_zone',
     }
-    _aud_seg_ops = Entity._enum({'AND', 'OR'}, 'OR')
-    _freq_int = Entity._enum({'hour', 'day', 'week', 'month', 'campaign',
+    _aud_seg_ops = t1types.enum({'AND', 'OR'}, 'OR')
+    _freq_int = t1types.enum({'hour', 'day', 'week', 'month', 'campaign',
                               'not-applicable'}, 'not-applicable')
-    _freq_type = Entity._enum({'even', 'asap', 'no-limit'}, 'no-limit')
-    _goal_type = Entity._enum({'spend', 'reach', 'cpc', 'cpe', 'cpa', 'roi'},
+    _freq_type = t1types.enum({'even', 'asap', 'no-limit'}, 'no-limit')
+    _goal_type = t1types.enum({'spend', 'reach', 'cpc', 'cpe', 'cpa', 'roi'},
                               'cpc')
-    _media_type = Entity._enum({'DISPLAY', 'VIDEO'}, 'DISPLAY')
-    _pac_int = Entity._enum({'hour', 'day'}, 'day')
-    _pac_type = Entity._enum({'even', 'asap'}, 'even')
-    _site_selec = Entity._enum({'MATHSELECT_250', 'EXCLUDE_UGC', 'ALL',
+    _media_type = t1types.enum({'DISPLAY', 'VIDEO'}, 'DISPLAY')
+    _pac_int = t1types.enum({'hour', 'day'}, 'day')
+    _pac_type = t1types.enum({'even', 'asap'}, 'even')
+    _site_selec = t1types.enum({'MATHSELECT_250', 'EXCLUDE_UGC', 'ALL',
                                 'REDUCED'}, 'REDUCED')
-    _supply_type = Entity._enum({'RTB', 'RMX_API', 'T1_RMX'}, 'RTB')
-    _type = Entity._enum({'REM', 'GBO', 'AUD'}, 'GBO')
+    _supply_type = t1types.enum({'RTB', 'RMX_API', 'T1_RMX'}, 'RTB')
+    _type = t1types.enum({'REM', 'GBO', 'AUD'}, 'GBO')
 
     _pull = {
         'audience_segment_exclude_op': None,
         'audience_segment_include_op': None,
         'bid_aggresiveness': float,
-        'bid_price_is_media_only': Entity._int_to_bool,
+        'bid_price_is_media_only': t1types.int_to_bool,
         'budget': float,
         'campaign_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'description': None,
         'effective_goal_value': float,
-        'end_date': Entity._strpt,
+        'end_date': t1types.strpt,
         'feature_compatibility': None,
         'frequency_amount': int,
         'frequency_interval': None,
@@ -60,22 +62,22 @@ class Strategy(Entity):
         'pacing_type': None,
         'pixel_target_expr': None,
         'roi_target': float,
-        'run_on_all_exchanges': Entity._int_to_bool,
-        'run_on_all_pmp': Entity._int_to_bool,
-        'run_on_display': Entity._int_to_bool,
-        'run_on_mobile': Entity._int_to_bool,
-        'run_on_streaming': Entity._int_to_bool,
-        'site_restriction_transparent_urls': Entity._int_to_bool,
+        'run_on_all_exchanges': t1types.int_to_bool,
+        'run_on_all_pmp': t1types.int_to_bool,
+        'run_on_display': t1types.int_to_bool,
+        'run_on_mobile': t1types.int_to_bool,
+        'run_on_streaming': t1types.int_to_bool,
+        'site_restriction_transparent_urls': t1types.int_to_bool,
         'site_selectiveness': None,
-        'start_date': Entity._strpt,
-        'status': Entity._int_to_bool,
+        'start_date': t1types.strpt,
+        'status': t1types.int_to_bool,
         'supply_type': None,
         'type': None,
-        'updated_on': Entity._strpt,
-        'use_campaign_end': Entity._int_to_bool,
-        'use_campaign_start': Entity._int_to_bool,
-        'use_mm_freq': Entity._int_to_bool,
-        'use_optimization': Entity._int_to_bool,
+        'updated_on': t1types.strpt,
+        'use_campaign_end': t1types.int_to_bool,
+        'use_campaign_start': t1types.int_to_bool,
+        'use_mm_freq': t1types.int_to_bool,
+        'use_optimization': t1types.int_to_bool,
         'version': int,
         'zone_name': None,
     }
@@ -84,7 +86,7 @@ class Strategy(Entity):
         'audience_segment_exclude_op': _aud_seg_ops,
         'audience_segment_include_op': _aud_seg_ops,
         'bid_price_is_media_only': int,
-        'end_date': partial(Entity._strft, null_on_none=True),
+        'end_date': partial(t1types.strft, null_on_none=True),
         'frequency_interval': _freq_int,
         'frequency_type': _freq_type,
         'goal_type': _goal_type,
@@ -98,7 +100,7 @@ class Strategy(Entity):
         'run_on_streaming': int,
         'site_restriction_transparent_urls': int,
         'site_selectiveness': _site_selec,
-        'start_date': partial(Entity._strft, null_on_none=True),
+        'start_date': partial(t1types.strft, null_on_none=True),
         'status': int,
         'supply_type': _supply_type,
         'type': _type,

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from functools import partial
 import re
 
-from terminalone import t1types
+from .. import t1types
 from ..config import PATHS
 from ..entity import Entity
 from ..utils import suppress

--- a/terminalone/models/strategyaudiencesegment.py
+++ b/terminalone/models/strategyaudiencesegment.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 from ..config import PATHS
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/strategyaudiencesegment.py
+++ b/terminalone/models/strategyaudiencesegment.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 from ..config import PATHS
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -16,14 +17,14 @@ class StrategyAudienceSegment(Entity):
     }
     _pull = {
         'audience_segment_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'group_identifier': None,
         'id': int,
         'operator': None,
         'restriction': None,
         'strategy_id': int,
         'type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'user_cpm': float,
         'version': int,
     }

--- a/terminalone/models/strategyconcept.py
+++ b/terminalone/models/strategyconcept.py
@@ -2,6 +2,8 @@
 """Provides strategy concept object."""
 
 from __future__ import absolute_import
+
+from terminalone import t1types
 from ..config import PATHS
 from ..entity import Entity
 
@@ -16,11 +18,11 @@ class StrategyConcept(Entity):
     }
     _pull = {
         'concept_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'strategy_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/strategyconcept.py
+++ b/terminalone/models/strategyconcept.py
@@ -2,7 +2,6 @@
 """Provides strategy concept object."""
 
 from __future__ import absolute_import
-
 from .. import t1types
 from ..config import PATHS
 from ..entity import Entity

--- a/terminalone/models/strategyconcept.py
+++ b/terminalone/models/strategyconcept.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from terminalone import t1types
+from .. import t1types
 from ..config import PATHS
 from ..entity import Entity
 

--- a/terminalone/models/strategydaypart.py
+++ b/terminalone/models/strategydaypart.py
@@ -2,7 +2,7 @@
 """Provides strategy day part object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 from ..config import PATHS
 

--- a/terminalone/models/strategydaypart.py
+++ b/terminalone/models/strategydaypart.py
@@ -2,6 +2,7 @@
 """Provides strategy day part object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 from ..config import PATHS
 
@@ -14,15 +15,15 @@ class StrategyDayPart(Entity):
         'strategy',
     }
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'days': None,
         'end_hour': int,
         'id': int,
         'start_hour': int,
-        'status': Entity._int_to_bool,
+        'status': t1types.int_to_bool,
         'strategy_id': int,
-        'udpated_on': Entity._strpt,
-        'user_time': Entity._int_to_bool,
+        'udpated_on': t1types.strpt,
+        'user_time': t1types.int_to_bool,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/strategydomain.py
+++ b/terminalone/models/strategydomain.py
@@ -2,7 +2,7 @@
 """Provides strategy domain restriction object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/strategydomain.py
+++ b/terminalone/models/strategydomain.py
@@ -2,6 +2,7 @@
 """Provides strategy domain restriction object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,14 +13,14 @@ class StrategyDomain(Entity):
     _relations = {
         'strategy',
     }
-    _restrictions = Entity._enum({'INCLUDE', 'EXCLUDE'}, '')
+    _restrictions = t1types.enum({'INCLUDE', 'EXCLUDE'}, '')
     _pull = {
-        'created_at': Entity._strpt,
+        'created_at': t1types.strpt,
         'domain': None,
         'id': int,
         'restriction': None,
         'strategy_id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/strategysupplysource.py
+++ b/terminalone/models/strategysupplysource.py
@@ -2,6 +2,7 @@
 """Provides strategy supply source object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/strategysupplysource.py
+++ b/terminalone/models/strategysupplysource.py
@@ -2,7 +2,7 @@
 """Provides strategy supply source object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/strategysupplysource.py
+++ b/terminalone/models/strategysupplysource.py
@@ -2,7 +2,6 @@
 """Provides strategy supply source object."""
 
 from __future__ import absolute_import
-from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/strategytargetingsegment.py
+++ b/terminalone/models/strategytargetingsegment.py
@@ -3,7 +3,9 @@
 
 from __future__ import absolute_import
 from ..config import PATHS
+from .. import t1types
 from ..entity import Entity
+from ..errors import ClientError
 
 
 class StrategyTargetingSegment(Entity):
@@ -15,7 +17,7 @@ class StrategyTargetingSegment(Entity):
         'strategy',
     }
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'group_identifier': None,
         'id': int,
         'operator': None,
@@ -23,7 +25,7 @@ class StrategyTargetingSegment(Entity):
         'strategy_id': int,
         'targeting_segment_id': int,
         'type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'user_cpm': float,
         'version': int,
     }

--- a/terminalone/models/supplysource.py
+++ b/terminalone/models/supplysource.py
@@ -2,7 +2,7 @@
 """Provides supply source object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/supplysource.py
+++ b/terminalone/models/supplysource.py
@@ -2,6 +2,7 @@
 """Provides supply source object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,31 +13,31 @@ class SupplySource(Entity):
     _relations = {
         'parent_supply',
     }
-    _rtb_types = Entity._enum({'STANDARD', 'MARKETPLACE'}, None)
-    _supply_types = Entity._enum({'exchange', 'data'}, None)
+    _rtb_types = t1types.enum({'STANDARD', 'MARKETPLACE'}, None)
+    _supply_types = t1types.enum({'exchange', 'data'}, None)
     _pull = {
         'bidder_exchange_identifier': int,
         'code': None,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'default_seat_identifier': None,
-        'distribute': Entity._int_to_bool,
-        'has_display': Entity._int_to_bool,
-        'has_mobile_display': Entity._int_to_bool,
-        'has_mobile_video': Entity._int_to_bool,
-        'has_video': Entity._int_to_bool,
+        'distribute': t1types.int_to_bool,
+        'has_display': t1types.int_to_bool,
+        'has_mobile_display': t1types.int_to_bool,
+        'has_mobile_video': t1types.int_to_bool,
+        'has_video': t1types.int_to_bool,
         'id': int,
-        'is_proservice': Entity._int_to_bool,
-        'mm_safe': Entity._int_to_bool,
+        'is_proservice': t1types.int_to_bool,
+        'mm_safe': t1types.int_to_bool,
         'parent_supply_id': int,
         'pixel_tag': None,
-        'pmp_enabled': Entity._int_to_bool,
-        'rtb_enabled': Entity._int_to_bool,
+        'pmp_enabled': t1types.int_to_bool,
+        'rtb_enabled': t1types.int_to_bool,
         'rtb_type': None,
-        'seat_enabled': Entity._int_to_bool,
-        'status': Entity._int_to_bool,
+        'seat_enabled': t1types.int_to_bool,
+        'status': t1types.int_to_bool,
         'supply_type': None,
-        'updated_on': Entity._strpt,
-        'use_pool': Entity._int_to_bool,
+        'updated_on': t1types.strpt,
+        'use_pool': t1types.int_to_bool,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/targetvalue.py
+++ b/terminalone/models/targetvalue.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import
 
-from terminalone import t1types
+from .. import t1types
 from ..errors import ClientError
 from ..entity import Entity
 

--- a/terminalone/models/targetvalue.py
+++ b/terminalone/models/targetvalue.py
@@ -2,6 +2,8 @@
 """Provides target value object."""
 
 from __future__ import absolute_import
+
+from terminalone import t1types
 from ..errors import ClientError
 from ..entity import Entity
 
@@ -20,7 +22,7 @@ class TargetValue(Entity):
         'code': None,
         'dimension_code': None,
         'id': int,
-        'is_targetable': Entity._int_to_bool,
+        'is_targetable': t1types.int_to_bool,
         'name': None,
         'target_dimension_id': int,
         'value': int,

--- a/terminalone/models/targetvalue.py
+++ b/terminalone/models/targetvalue.py
@@ -2,7 +2,6 @@
 """Provides target value object."""
 
 from __future__ import absolute_import
-
 from .. import t1types
 from ..errors import ClientError
 from ..entity import Entity

--- a/terminalone/models/user.py
+++ b/terminalone/models/user.py
@@ -2,7 +2,7 @@
 """Provides user object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/user.py
+++ b/terminalone/models/user.py
@@ -2,6 +2,7 @@
 """Provides user object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -12,44 +13,44 @@ class User(Entity):
     _relations = {
         'creator',
     }
-    _role = Entity._enum({'ADMIN', 'MANAGER', 'REPORTER'}, 'REPORTER')
-    _scope = Entity._enum({'GLOBAL', 'SELECT'}, 'SELECT')
-    _type = Entity._enum({'INTERNAL', 'AGENCY', 'VPAN', 'ADVERTISER'},
+    _role = t1types.enum({'ADMIN', 'MANAGER', 'REPORTER'}, 'REPORTER')
+    _scope = t1types.enum({'GLOBAL', 'SELECT'}, 'SELECT')
+    _type = t1types.enum({'INTERNAL', 'AGENCY', 'VPAN', 'ADVERTISER'},
                          'ADVERTISER')
     _pull = {
-        'access_internal_fees': Entity._int_to_bool,
-        'active': Entity._int_to_bool,
-        'created_on': Entity._strpt,
+        'access_internal_fees': t1types.int_to_bool,
+        'active': t1types.int_to_bool,
+        'created_on': t1types.strpt,
         'creator_id': int,
-        'edit_data_definition': Entity._int_to_bool,
-        'edit_campaigns': Entity._int_to_bool,
-        'edit_margins_and_performance': Entity._int_to_bool,
-        'edit_segments': Entity._int_to_bool,
+        'edit_data_definition': t1types.int_to_bool,
+        'edit_campaigns': t1types.int_to_bool,
+        'edit_margins_and_performance': t1types.int_to_bool,
+        'edit_segments': t1types.int_to_bool,
         'fax': None,
         'first_name': None,
         'id': int,
-        'labs_enable_rmx': Entity._int_to_bool,
-        'last_login_on': Entity._strpt,
+        'labs_enable_rmx': t1types.int_to_bool,
+        'last_login_on': t1types.strpt,
         'last_name': None,
-        'link_ldap': Entity._int_to_bool,
+        'link_ldap': t1types.int_to_bool,
         'mobile': None,
         'password': None,
-        'password_reset_sent': Entity._strpt,
+        'password_reset_sent': t1types.strpt,
         'password_reset_token': None,
         'phone': None,
         'role': None,
         'scope': None,
-        'sso_auth_sent': Entity._strpt,
+        'sso_auth_sent': t1types.strpt,
         'sso_auth_token': None,
         'title': None,
         'type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'username': None,
         'version': int,
-        'view_data_definition': Entity._int_to_bool,
-        'view_dmp_reports': Entity._int_to_bool,
-        'view_organizations': Entity._int_to_bool,
-        'view_segments': Entity._int_to_bool,
+        'view_data_definition': t1types.int_to_bool,
+        'view_dmp_reports': t1types.int_to_bool,
+        'view_organizations': t1types.int_to_bool,
+        'view_segments': t1types.int_to_bool,
     }
     _push = _pull.copy()
     _push.update({

--- a/terminalone/models/vendor.py
+++ b/terminalone/models/vendor.py
@@ -2,7 +2,7 @@
 """Provides vendor object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/vendor.py
+++ b/terminalone/models/vendor.py
@@ -2,6 +2,7 @@
 """Provides vendor object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -13,27 +14,27 @@ class Vendor(Entity):
         'vendor_contracts',
         'vendor_domains',
     }
-    # _rate_card_types = Entity._enum({'CPM', 'FIXED'}, None)
-    _vendor_types = Entity._enum({'AD_SERVER', 'AD_VERIFICATION', 'CONTEXTUAL',
+    # _rate_card_types = t1types.enum({'CPM', 'FIXED'}, None)
+    _vendor_types = t1types.enum({'AD_SERVER', 'AD_VERIFICATION', 'CONTEXTUAL',
                                   'DATA', 'DSP', 'DYNAMIC_CREATIVE', 'NETWORK',
                                   'OBA_COMPLIANCE', 'OTHER', 'PIXEL_TRACKING',
                                   'RICH_MEDIA', 'SURVEY'}, 'OTHER')
     _pull = {
-        'adx_approved': Entity._int_to_bool,
-        'adx_declaration_required': Entity._int_to_bool,
-        'adx_ssl_approved': Entity._int_to_bool,
+        'adx_approved': t1types.int_to_bool,
+        'adx_declaration_required': t1types.int_to_bool,
+        'adx_ssl_approved': t1types.int_to_bool,
         'adx_vendor_identifier': None,
-        'adx_video_approved': Entity._int_to_bool,
-        'adx_video_ssl_approved': Entity._int_to_bool,
-        'created_on': Entity._strpt,
+        'adx_video_approved': t1types.int_to_bool,
+        'adx_video_ssl_approved': t1types.int_to_bool,
+        'created_on': t1types.strpt,
         'description': None,
         'id': int,
-        'is_eligible': Entity._int_to_bool,
-        'mm_contract_available': Entity._int_to_bool,
+        'is_eligible': t1types.int_to_bool,
+        'mm_contract_available': t1types.int_to_bool,
         'name': None,
         'rate_card_price': float,
         'rate_card_type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'vendor_type': None,
         'version': int,
         'wholesale_price': float,

--- a/terminalone/models/vendorcontract.py
+++ b/terminalone/models/vendorcontract.py
@@ -2,7 +2,7 @@
 """Provides vendor_contract object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/vendorcontract.py
+++ b/terminalone/models/vendorcontract.py
@@ -2,6 +2,7 @@
 """Provides vendor_contract object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -15,12 +16,12 @@ class VendorContract(Entity):
     }
     _pull = {
         'campaign_id': int,
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'id': int,
         'price': float,
         'rate_card_type': None,
-        'updated_on': Entity._strpt,
-        'use_mm_contract': Entity._int_to_bool,
+        'updated_on': t1types.strpt,
+        'use_mm_contract': t1types.int_to_bool,
         'vendor_id': int,
         'version': int,
     }

--- a/terminalone/models/vendordomain.py
+++ b/terminalone/models/vendordomain.py
@@ -2,6 +2,7 @@
 """Provides vendor_domain object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -15,11 +16,11 @@ class VendorDomain(Entity):
         'vendor_pixel_domains',
     }
     _pull = {
-        'allow_subdomain_match': Entity._int_to_bool,
-        'created_on': Entity._strpt,
+        'allow_subdomain_match': t1types.int_to_bool,
+        'created_on': t1types.strpt,
         'domain': None,
         'id': int,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'vendor_id': int,
         'version': int,
     }

--- a/terminalone/models/vendordomain.py
+++ b/terminalone/models/vendordomain.py
@@ -2,7 +2,7 @@
 """Provides vendor_domain object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/vendorpixel.py
+++ b/terminalone/models/vendorpixel.py
@@ -2,7 +2,7 @@
 """Provides vendor_pixel object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/vendorpixel.py
+++ b/terminalone/models/vendorpixel.py
@@ -2,6 +2,7 @@
 """Provides vendor_pixel object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -13,15 +14,15 @@ class VendorPixel(Entity):
         'creative',
         'vendor_pixel_domains',
     }
-    _set_bys = Entity._enum({'SYSTEM', 'USER'}, 'USER')
+    _set_bys = t1types.enum({'SYSTEM', 'USER'}, 'USER')
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'creative_id': int,
         'id': int,
         'set_by': None,
         'tag': None,
         'tag_type': None,
-        'updated_on': Entity._strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
     _push = _pull.copy()

--- a/terminalone/models/vendorpixeldomain.py
+++ b/terminalone/models/vendorpixeldomain.py
@@ -2,7 +2,7 @@
 """Provides vendor_pixel_domain object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/vendorpixeldomain.py
+++ b/terminalone/models/vendorpixeldomain.py
@@ -2,6 +2,7 @@
 """Provides vendor_pixel_domain object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -15,7 +16,7 @@ class VendorPixelDomain(Entity):
         'vendor_pixel',
     }
     _pull = {
-        'created_on': Entity._strpt,
+        'created_on': t1types.strpt,
         'domain': None,
         'id': int,
         'vendor_domain_id': int,

--- a/terminalone/models/vertical.py
+++ b/terminalone/models/vertical.py
@@ -2,7 +2,7 @@
 """Provides vertical object."""
 
 from __future__ import absolute_import
-from terminalone import t1types
+from .. import t1types
 from ..entity import Entity
 
 

--- a/terminalone/models/vertical.py
+++ b/terminalone/models/vertical.py
@@ -2,6 +2,7 @@
 """Provides vertical object."""
 
 from __future__ import absolute_import
+from terminalone import t1types
 from ..entity import Entity
 
 
@@ -16,8 +17,8 @@ class Vertical(Entity):
     _pull = {
         'id': int,
         'name': None,
-        'created_on': Entity._strpt,
-        'updated_on': Entity._strpt,
+        'created_on': t1types.strpt,
+        'updated_on': t1types.strpt,
         'version': int,
     }
 

--- a/terminalone/t1types.py
+++ b/terminalone/t1types.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+"""Provides field type conversion functions T1 data classes."""
+
+from datetime import datetime
+from terminalone.utils import FixedOffset
+
+
+def int_to_bool(value):
+    """Convert integer string {"0","1"} to its corresponding bool"""
+    try:
+        return bool(int(value))
+    except ValueError:
+        raise TypeError('must supply integer string')
+
+
+def none_to_empty(val):
+    """Convert None to empty string.
+
+    Necessary for fields that are required POST but have no logical value.
+    """
+    if val is None:
+        return ""
+    return val
+
+
+def enum(all_vars, default):
+    """Check input against accepted set or return a default."""
+
+    def get_value(test_value):
+        if test_value in all_vars:
+            return test_value
+        else:
+            return default
+
+    return get_value
+
+
+def default_empty(default):
+    """Check an input against its falsy value or return a default."""
+
+    def get_value(test_value):
+        if test_value:
+            return test_value
+        else:
+            return default
+
+    return get_value
+
+
+def strpt(dt_string):
+    """Convert ISO string time to datetime.datetime. No-op on datetimes"""
+    if isinstance(dt_string, datetime):
+        return dt_string
+    if dt_string[-5] == '-' or dt_string[-5] == '+':
+        offset_str = dt_string[-5:]
+        dt_string = dt_string[:-5]
+        offset = int(offset_str[-4:-2]) * 60 + int(offset_str[-2:])
+        if offset_str[0] == "-":
+            offset = -offset
+    else:
+        offset = 0
+
+    return datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=FixedOffset(offset))
+
+
+def strft(dt_obj, null_on_none=False):
+    """Convert datetime.datetime to ISO string.
+
+    :param null_on_none: bool Occasionally, we will actually want to send an
+        empty string where a datetime would typically go. For instance, if a
+        strategy has an end_date set, but then wants to change to use
+        campaign end date, the POST will normally omit the end_date field
+        (because you cannot send it with use_campaign_end).
+        However, this will cause an error because there was an end_date set
+        previously. So, we need to send an empty string to indicate that it
+        should be nulled out. In cases like this, null_on_none should be set
+        to True in the entity's _push dict using a partial to make it a
+        single-argument function. See strategy.py
+    :raise AttributeError: if not provided a datetime
+    :return: str
+    """
+    try:
+        return dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
+    except AttributeError:
+        if dt_obj is None and null_on_none:
+            return ""
+        raise


### PR DESCRIPTION
The main fix here is to throw more helpful errors when attempting to set a field of the wrong type (which can happen implicitly sometimes on embedded objects).
Also a refactor to pull out the custom types into their own module, reducing the amount of code in Entity.py