### PR TITLE
Set iterators in parsers

### DIFF
--- a/terminalone/connection.py
+++ b/terminalone/connection.py
@@ -175,7 +175,6 @@ class Connection(object):
         if user is None:
             user, _ = self._get(PATHS['mgmt'], 'session')
 
-        user = next(user)
         Connection.__setattr__(self, 'user_id',
                                int(user['id']))
         Connection.__setattr__(self, 'username',
@@ -219,4 +218,4 @@ class Connection(object):
         except Exception:
             Connection.__setattr__(self, 'response', response)
             raise
-        return iter(result.entities), result.entity_count
+        return result.entities, result.entity_count

--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -192,7 +192,7 @@ class Entity(Connection):
         else:
             data = self._validate_write(self.properties)
         entity, _ = super(Entity, self)._post(PATHS['mgmt'], url, data=data)
-        self._update_self(next(entity))
+        self._update_self(entity)
 
     def update(self, *args, **kwargs):
         """Alias for save"""

--- a/terminalone/service.py
+++ b/terminalone/service.py
@@ -2,6 +2,7 @@
 """Provides service object for T1."""
 
 from __future__ import absolute_import, division
+from collections import Iterator
 from itertools import chain
 from types import GeneratorType
 from .connection import Connection
@@ -506,8 +507,8 @@ class T1(Connection):
 
         entities, ent_count = super(T1, self)._get(PATHS['mgmt'], _url, params=_params)
 
-        if ent_count == 1:
-            return self._return_class(next(entities), child, child_id, entity, collection)
+        if not isinstance(entities, GeneratorType) and not isinstance(entities, Iterator):
+            return self._return_class(entities, child, child_id, entity, collection)
 
         ent_gen = self._gen_classes(entities, child, child_id, entity, collection)
         if count:


### PR DESCRIPTION
Nathan originally brought this up in #87 . In a lot of the service methods, we are expecting all entities to be an iterator, and using entity_count to see if something is a single entity or a collection. However, this doesn't account for instances where, for instance, you request a collection but it only has a single entity. We make it an iterator as we should, but the caller thinks it's an entity, so it chokes. 

Here, we set iterators in the parsers themselves, such that callers only need check if something is an iterator. We can then check that in the service methods to determine how to parse the object.

@FodT @Cawb07 this is a fairly comprehensive change, so I could use a couple of CRs to make sure I haven't overlooked anything. It passes unit tests and acceptance tests, but could use some real-world and edge-case testing.