### PR TITLE
Safely reinitialize strategy fields

### DIFF
--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -264,11 +264,12 @@ class Strategy(Entity):
         # Re-set the fields so that if the same object get saved, we
         # compare agains the re-initialized values
         self._deserialize_target_expr()
-        super(Entity, self).__setattr__('_init_impcap', self.impression_cap)
+        super(Entity, self).__setattr__('_init_impcap',
+                                        self.properties.get('impression_cap'))
         super(Entity, self).__setattr__('_init_imppac',
-                                        (self.impression_pacing_type,
-                                         self.impression_pacing_amount,
-                                         self.impression_pacing_interval))
+                                        (self.properties.get('impression_pacing_type'),
+                                         self.properties.get('impression_pacing_amount'),
+                                         self.properties.get('impression_pacing_interval')))
 
     @property
     def pixel_target_expr_string(self):


### PR DESCRIPTION
Related to #98. In some cases (e.g. strategy ID 1584681) the API doesn't return the old field impression_cap. Perhaps Adama uses some heuristics as well to see if new fields are being used. We need to use .get to re-initialize strategy fields in case they aren't returned.