### PR TITLE
fix initialising of _init values

### DIFF
--- a/terminalone/models/campaign.py
+++ b/terminalone/models/campaign.py
@@ -100,6 +100,8 @@ class Campaign(Entity):
     })
 
     def __init__(self, session, properties=None, **kwargs):
+        super(Campaign, self).__init__(session, properties, **kwargs)
+
         if properties is None:
             # super(Entity) supers to grandparent
             super(Entity, self).__setattr__('_init_sce', None)
@@ -109,7 +111,6 @@ class Campaign(Entity):
                                             properties.get('spend_cap_enabled'))
             super(Entity, self).__setattr__('_init_sct',
                                             properties.get('spend_cap_type'))
-        super(Campaign, self).__init__(session, properties, **kwargs)
 
     def _migration_asst(self):
         """Helps migrate users to the new impression pacing features.

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -125,6 +125,8 @@ class Strategy(Entity):
     _readonly = Entity._readonly | {'effective_goal_value', 'zone_name'}
 
     def __init__(self, session, properties=None, **kwargs):
+        super(Strategy, self).__init__(session, properties, **kwargs)
+
         if properties is None:
             # super(Entity) supers to grandparent
             super(Entity, self).__setattr__('_init_impcap', None)
@@ -136,7 +138,7 @@ class Strategy(Entity):
                                             (properties.get('impression_pacing_type'),
                                              properties.get('impression_pacing_amount'),
                                              properties.get('impression_pacing_interval')))
-        super(Strategy, self).__init__(session, properties, **kwargs)
+
         try:
             self.pixel_target_expr
         except AttributeError:


### PR DESCRIPTION
`_init_sce` in Campaign objects was being set before the Entity constructor parsed the `spend_cap_enabled` property from an integer to a boolean. This was causing a failed comparison in the first case of the `_migration_asst()` comparison when nothing had changed, as `_init_sce` was a string being compared to a Boolean. 

The net result being that pulling a campaign, changing some unrelated fields and then saving() was causing `spend_cap_type` to be removed from the POST body instead of both fields. Then Adama's API  steps in when it doesn't see the new field and substitutes a default value. 

This also applied to Strategies. Fixed by moving `super()` call up to before these fields are grabbed. 