### PR TITLE
107 microservices

### DIFF
--- a/terminalone/config.py
+++ b/terminalone/config.py
@@ -16,7 +16,8 @@ ACCEPT_HEADERS = {
     'xml': ['text/xml', 'application/xml']
 }
 
-PATHS = {
+SERVICE_BASE_PATHS = {
+    'deals': 'media/v1.0',
     'mgmt': 'api/v2.0',
     'reports': 'reporting/v1/std',
     'uniques': 'uniques/v1',

--- a/terminalone/connection.py
+++ b/terminalone/connection.py
@@ -186,16 +186,19 @@ class Connection(object):
         response = self.session.get(url, params=params, stream=True)
         return self._parse_response(response)
 
-    def _post(self, path, rest, data):
+    def _post(self, path, rest, data=None, json=None):
         """Base method for subclasses to call.
         :param url: str API URL
-        :param data: dict POST data
+        :param data: dict POST data for formdata posts
+        :param json: dict POST data for json posts
         """
-        if not data:
+        if not data and not json:
             raise ClientError('No POST data.')
+        if data and json:
+            raise ClientError('Cannot specify both data and json POST data.')
 
         url = '/'.join(['https:/', self.api_base, path, rest])
-        response = self.session.post(url, data=data, stream=True)
+        response = self.session.post(url, data=data, json=json, stream=True)
         return self._parse_response(response)
 
     def _parse_response(self, response):
@@ -221,5 +224,5 @@ class Connection(object):
 
     def _get_service_path(self, entity_name=None):
         if not entity_name:
-            entity_name = self.resource
+            entity_name = self.collection
         return SERVICE_BASE_PATHS.get(entity_name, SERVICE_BASE_PATHS['mgmt'])

--- a/terminalone/connection.py
+++ b/terminalone/connection.py
@@ -218,3 +218,8 @@ class Connection(object):
             Connection.__setattr__(self, 'response', response)
             raise
         return result.entities, result.entity_count
+
+    def _get_service_path(self, entity_name=None):
+        if not entity_name:
+            entity_name = self.resource
+        return SERVICE_BASE_PATHS.get(entity_name, SERVICE_BASE_PATHS['mgmt'])

--- a/terminalone/connection.py
+++ b/terminalone/connection.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 from requests import Session
 from requests.utils import default_user_agent
 from requests_oauthlib import OAuth2Session
-from .config import ACCEPT_HEADERS, API_BASES, PATHS, VALID_ENVS
+from .config import ACCEPT_HEADERS, API_BASES, SERVICE_BASE_PATHS, VALID_ENVS
 from .errors import ClientError, ParserException
 from .metadata import __version__
 from .xmlparser import XMLParser, ParseError
@@ -60,7 +60,7 @@ class Connection(object):
 
     def _oauth2_session(self, **kwargs):
         refresh_url = '/'.join(['https:/', self.api_base,
-                                PATHS['oauth2'], 'token'])
+                                SERVICE_BASE_PATHS['oauth2'], 'token'])
         refresh_kwargs = {'client_id': self.auth_params['api_key'],
                           'client_secret': self.auth_params['client_secret']}
         session = OAuth2Session(
@@ -96,7 +96,7 @@ class Connection(object):
         The traditional way of authenticating by making a POST request to /login
         endpoint and storing the returned session cookie.
         """
-        user, _ = self._post(PATHS['mgmt'], 'login', data={
+        user, _ = self._post(SERVICE_BASE_PATHS['mgmt'], 'login', data={
             'user': username,
             'password': password,
             'api_key': api_key,
@@ -133,7 +133,7 @@ class Connection(object):
     def authorization_url(self, redirect_uri=None):
         """Authenticate using OAuth2"""
         auth_url = '/'.join(['https:/', self.api_base,
-                             PATHS['oauth2'], 'authorize'])
+                             SERVICE_BASE_PATHS['oauth2'], 'authorize'])
         if redirect_uri is None:
             try:
                 redirect_uri = self.auth_params['redirect_uri']
@@ -147,7 +147,7 @@ class Connection(object):
                     authorization_response_url=None, set_session=False):
         token_url = '/'.join(['https:/',
                               self.api_base,
-                              PATHS['oauth2'],
+                              SERVICE_BASE_PATHS['oauth2'],
                               'token'])
         session = self._oauth2_session(state=state)
         token = session.fetch_token(
@@ -167,7 +167,7 @@ class Connection(object):
         check session
         """
         if user is None:
-            user, _ = self._get(PATHS['mgmt'], 'session')
+            user, _ = self._get(SERVICE_BASE_PATHS['mgmt'], 'session')
 
         Connection.__setattr__(self, 'user_id',
                                int(user['id']))

--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import, division
 from warnings import warn
-from .config import SERVICE_BASE_PATHS
 from .connection import Connection
 from .errors import ClientError
 from .vendor import six
@@ -207,9 +206,6 @@ class Entity(Connection):
         url = self._construct_url(addl=['history', ])
         history, _ = super(Entity, self)._get(self._get_service_path(), url)
         return history
-
-    def _get_service_path(self):
-        return SERVICE_BASE_PATHS.get(self.resource, SERVICE_BASE_PATHS['mgmt'])
 
 
 class SubEntity(Entity):

--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division
 from warnings import warn
-from .config import PATHS
+from .config import SERVICE_BASE_PATHS
 from .connection import Connection
 from .errors import ClientError
 from .vendor import six
@@ -193,7 +193,7 @@ class Entity(Connection):
             data = self._validate_write(data)
         else:
             data = self._validate_write(self.properties)
-        entity, _ = super(Entity, self)._post(PATHS['mgmt'], url, data=data)
+        entity, _ = super(Entity, self)._post(self._get_service_path(), url, data=data)
         self._update_self(entity)
 
     def update(self, *args, **kwargs):
@@ -205,8 +205,11 @@ class Entity(Connection):
         if not self.properties.get('id'):
             raise ClientError('Entity ID not given')
         url = self._construct_url(addl=['history', ])
-        history, _ = super(Entity, self)._get(PATHS['mgmt'], url)
+        history, _ = super(Entity, self)._get(self._get_service_path(), url)
         return history
+
+    def _get_service_path(self):
+        return SERVICE_BASE_PATHS.get(self.resource, SERVICE_BASE_PATHS['mgmt'])
 
 
 class SubEntity(Entity):

--- a/terminalone/entity.py
+++ b/terminalone/entity.py
@@ -42,7 +42,7 @@ class Entity(Connection):
             return
 
         for attr, val in six.iteritems(properties):
-            if self._pull.get(attr) is not None:
+            if self._pull.get(attr) is not None and val is not None:
                 properties[attr] = self._pull[attr](val)
         super(Entity, self).__setattr__('properties', properties)
 
@@ -105,13 +105,6 @@ class Entity(Connection):
         """Custom unpickling. TODO"""
         return super(Entity, self).__setstate__(state)
 
-    def _validate_read(self, data):
-        """Convert XML strings to Python objects"""
-        for key, value in six.iteritems(data):
-            if key in self._pull:
-                data[key] = self._pull[key](value)
-        return data
-
     def _conds_for_removal(self, key, update, push_fn):
         """Determine if an attribute should be removed before POST.
 
@@ -125,7 +118,7 @@ class Entity(Connection):
                 push_fn is False)
 
     def _validate_write(self, data):
-        """Convert Python objects to XML values.
+        """Convert Python objects to POST values.
 
         If attribute should not be sent, remove it from the body.
         """

--- a/terminalone/jsonparser.py
+++ b/terminalone/jsonparser.py
@@ -59,7 +59,10 @@ class JSONParser(object):
                 data.get('enabled') is not None:
             self.entities = self._parse_target_dimensions(data)
 
-        elif data.get('permissions') is not None:
+        # FIXME: permissions responses dont have an 'entity_type' field so we're using the
+        # FIXME: absence of this field to identify whether it's a permissions object
+        # FIXME: or just a field named 'permissions'. As always, negative tests are bad. baaaaad.
+        elif data.get('permissions') is not None and data.get('entity_type') is None:
             self.entities = self._parse_permissions(data['permissions'])
 
         else:

--- a/terminalone/models/deal.py
+++ b/terminalone/models/deal.py
@@ -10,52 +10,37 @@ class Deal(Entity):
     """docstring for deals."""
     collection = 'deals'
     resource = 'deal'
-    _relations = {
-        'advertiser',
-        'publisher',
-        'supply_source',
-    }
     _bill_types = t1types.enum({'EXCHANGE', 'PUBLISHER', 'NONE'}, 'EXCHANGE')
-    _deal_sources = t1types.enum({'USER', 'INTERNAL'}, 'INTERNAL')
-    _media_types = t1types.enum({'DISPLAY', 'VIDEO'}, 'DISPLAY')
     _price_methods = t1types.enum({'CPM'}, 'CPM')
     _price_types = t1types.enum({'FIXED', 'FLOOR'}, None)
     _pull = {
-        'advertiser_id': int,
-        'bill_type': None,
         'created_on': t1types.strpt,
-        'currency_code': None,
         'deal_identifier': None,
-        'deal_source': None,
         'description': None,
         'end_datetime': t1types.strpt,
         'id': int,
-        'media_type': None,
         'name': None,
-        'partner_sourced': t1types.int_to_bool,
-        'price': float,
+        'bill_type': None,
+        'owner': dict,
+        'price': dict,
         'price_method': None,
         'price_type': None,
-        'publisher_id': int,
         'start_datetime': t1types.strpt,
-        'status': t1types.int_to_bool,
+        'status': bool,
         'supply_source_id': int,
+        'sub_supply_source_id': int,
         'updated_on': t1types.strpt,
-        'version': int,
         'zone_name': None,
     }
     _push = _pull.copy()
     _push.update({
         'bill_type': _bill_types,
-        'deal_source': _deal_sources,
         'end_datetime': t1types.strft,
-        'media_type': _media_types,
-        'partner_sourced': int,
         'price_method': _price_methods,
         'price_type': _price_types,
         'start_datetime': t1types.strft,
-        'status': int,
     })
 
     def __init__(self, session, properties=None, **kwargs):
         super(Deal, self).__init__(session, properties, **kwargs)
+

--- a/terminalone/models/deal.py
+++ b/terminalone/models/deal.py
@@ -2,6 +2,9 @@
 """Provides deal object for PMP-E and Global Deals."""
 
 from __future__ import absolute_import
+
+from functools import partial
+
 from .. import t1types
 from ..entity import Entity
 
@@ -10,6 +13,7 @@ class Deal(Entity):
     """docstring for deals."""
     collection = 'deals'
     resource = 'deal'
+    _post_format = 'json'
     _bill_types = t1types.enum({'EXCHANGE', 'PUBLISHER', 'NONE'}, 'EXCHANGE')
     _price_methods = t1types.enum({'CPM'}, 'CPM')
     _price_types = t1types.enum({'FIXED', 'FLOOR'}, None)
@@ -22,6 +26,7 @@ class Deal(Entity):
         'name': None,
         'bill_type': None,
         'owner': dict,
+        'permissions': dict,
         'price': dict,
         'price_method': None,
         'price_type': None,
@@ -35,10 +40,10 @@ class Deal(Entity):
     _push = _pull.copy()
     _push.update({
         'bill_type': _bill_types,
-        'end_datetime': t1types.strft,
+        'end_datetime': partial(t1types.strft, offset=True),
         'price_method': _price_methods,
         'price_type': _price_types,
-        'start_datetime': t1types.strft,
+        'start_datetime': partial(t1types.strft, offset=True),
     })
 
     def __init__(self, session, properties=None, **kwargs):

--- a/terminalone/models/deal.py
+++ b/terminalone/models/deal.py
@@ -43,4 +43,3 @@ class Deal(Entity):
 
     def __init__(self, session, properties=None, **kwargs):
         super(Deal, self).__init__(session, properties, **kwargs)
-

--- a/terminalone/models/pixel.py
+++ b/terminalone/models/pixel.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 
-from ..config import PATHS
 from .. import t1types
 from ..entity import Entity
 
@@ -41,6 +40,6 @@ class ChildPixel(Entity):
         url = '/'.join([self.collection,
                         str(self.id),
                         'delete'])
-        self._post(PATHS['mgmt'], rest=url, data={'version': self.version})
+        self._post(self._get_service_path(), rest=url, data={'version': self.version})
         for item in list(self.properties.keys()):
             del self.properties[item]

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 from functools import partial
 import re
 from .. import t1types
-from ..config import PATHS
 from ..entity import Entity
 from ..utils import suppress
 
@@ -206,7 +205,7 @@ class Strategy(Entity):
 
     def save_supplies(self, data):
         url = self._construct_url(addl=['supplies', ])
-        entity, _ = super(Strategy, self)._post(PATHS['mgmt'], url, data)
+        entity, _ = super(Strategy, self)._post(self._get_service_path(), url, data)
         self._update_self(entity)
         self._deserialize_target_expr()
         if 'relations' in self.properties:
@@ -217,17 +216,17 @@ class Strategy(Entity):
         # this endpoint doesn't return an entity like the supplies endpoint
         # so we ignore the error
         with suppress(AttributeError):
-            entity, _ = super(Strategy, self)._post(PATHS['mgmt'], url, data)
+            entity, _ = super(Strategy, self)._post(self._get_service_path(), url, data)
 
             # you can't get these values so we don't need to reset anything
 
     def save_audience_segments(self, data):
         url = self._construct_url(addl=['audience_segments', ])
-        entity, _ = super(Strategy, self)._post(PATHS['mgmt'], url, data)
+        entity, _ = super(Strategy, self)._post(self._get_service_path(), url, data)
 
     def save_targeting_segments(self, data):
         url = self._construct_url(addl=['targeting_segments', ])
-        entity, _ = super(Strategy, self)._post(PATHS['mgmt'], url, data)
+        entity, _ = super(Strategy, self)._post(self._get_service_path(), url, data)
 
     def _serialize_target_expr(self):
         """Serialize pixel_target_expr dict into string"""

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -205,6 +205,13 @@ class Strategy(Entity):
 
     def save_supplies(self, data):
         url = self._construct_url(addl=['supplies', ])
+        self._save_related(data, url)
+
+    def save_deals(self, data):
+        url = self._construct_url(addl=['deals', ])
+        self._save_related(data, url)
+
+    def _save_related(self, data, url):
         entity, _ = super(Strategy, self)._post(self._get_service_path(), url, data)
         self._update_self(entity)
         self._deserialize_target_expr()

--- a/terminalone/models/strategyaudiencesegment.py
+++ b/terminalone/models/strategyaudiencesegment.py
@@ -2,7 +2,6 @@
 """Provides strategy audience segment object."""
 
 from __future__ import absolute_import
-from ..config import PATHS
 from .. import t1types
 from ..entity import Entity
 
@@ -46,6 +45,6 @@ class StrategyAudienceSegment(Entity):
             'exclude_op': 'OR',
             'include_op': 'OR',
         }
-        self._post(PATHS['mgmt'], rest=url, data=data)
+        self._post(self._get_service_path(), rest=url, data=data)
         for item in list(self.properties.keys()):
             del self.properties[item]

--- a/terminalone/models/strategyconcept.py
+++ b/terminalone/models/strategyconcept.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 from .. import t1types
-from ..config import PATHS
 from ..entity import Entity
 
 
@@ -42,6 +41,6 @@ class StrategyConcept(Entity):
         url = '/'.join([self.collection,
                         str(self.id),
                         'delete'])
-        self._post(PATHS['mgmt'], rest=url, data={'version': self.version})
+        self._post(self.get_service_path(), rest=url, data={'version': self.version})
         for item in list(self.properties.keys()):
             del self.properties[item]

--- a/terminalone/models/strategydaypart.py
+++ b/terminalone/models/strategydaypart.py
@@ -4,7 +4,6 @@
 from __future__ import absolute_import
 from .. import t1types
 from ..entity import Entity
-from ..config import PATHS
 
 
 class StrategyDayPart(Entity):
@@ -40,6 +39,6 @@ class StrategyDayPart(Entity):
         url = '/'.join([self.collection,
                         str(self.id),
                         'delete'])
-        self._post(PATHS['mgmt'], rest=url, data={'version': self.version})
+        self._post(self._get_service_path(), rest=url, data={'version': self.version})
         for item in list(self.properties.keys()):
             del self.properties[item]

--- a/terminalone/models/strategytargetingsegment.py
+++ b/terminalone/models/strategytargetingsegment.py
@@ -2,7 +2,6 @@
 """Provides strategy targeting segment object."""
 
 from __future__ import absolute_import
-from ..config import PATHS
 from .. import t1types
 from ..entity import Entity
 from ..errors import ClientError
@@ -48,6 +47,6 @@ class StrategyTargetingSegment(Entity):
             'exclude_op': 'OR',
             'include_op': 'OR',
         }
-        self._post(PATHS['mgmt'], rest=url, data=data)
+        self._post(self._get_service_path(), rest=url, data=data)
         for item in list(self.properties.keys()):
             del self.properties[item]

--- a/terminalone/models/targetdimension.py
+++ b/terminalone/models/targetdimension.py
@@ -59,7 +59,7 @@ class TargetDimension(SubEntity):
             # TargetDimension doesn't have a version associated.
             # But we want to use .save, rather than ._post.
             # As such, we need to have a version number included.
-            # Setting it to None will make _validate_write yank it from the body
+            # Setting it to None will make _validate_form_post yank it from the body
             'version': None,
         })
 

--- a/terminalone/models/targetdimension.py
+++ b/terminalone/models/targetdimension.py
@@ -3,7 +3,6 @@
 
 from __future__ import absolute_import
 from warnings import warn
-from ..config import PATHS
 from ..errors import ClientError
 from ..entity import Entity, SubEntity
 from .targetvalue import TargetValue
@@ -77,7 +76,7 @@ class TargetDimension(SubEntity):
         if hasattr(target, '__iter__'):
             for child_id in target:
                 url[1] = str(child_id)
-                entities, _ = super(TargetDimension, self)._get(PATHS['mgmt'],
+                entities, _ = super(TargetDimension, self)._get(self._get_service_path(),
                                                                 '/'.join(url))
                 group.append(TargetValue(self.session,
                                          properties=next(entities),

--- a/terminalone/reports.py
+++ b/terminalone/reports.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, division
 import csv
-from .config import PATHS
+from .config import SERVICE_BASE_PATHS
 from .connection import Connection
 from .errors import ClientError, T1Error
 from .utils import compose
@@ -85,7 +85,7 @@ class Report(Connection):
         :param path: str path to hit. Should not start with slash
         :param params: dict query string params
         """
-        url = '/'.join(['https:/', self.api_base, PATHS['reports'], path])
+        url = '/'.join(['https:/', self.api_base, SERVICE_BASE_PATHS['reports'], path])
         response = self.session.get(url, params=params, stream=True)
 
         if not response.ok:

--- a/terminalone/service.py
+++ b/terminalone/service.py
@@ -11,7 +11,7 @@ from .entity import Entity
 from .errors import ClientError
 from .reports import Report
 from .utils import filters
-from .config import PATHS
+from .config import SERVICE_BASE_PATHS
 from .vendor import six
 
 
@@ -347,7 +347,7 @@ class T1(Connection):
             _params = self._construct_params(entity, include, full, page_limit,
                                              page_offset, sort_by, parent, query)
 
-        entities, ent_count = super(T1, self)._get(PATHS['mgmt'], _url, params=_params)
+        entities, ent_count = super(T1, self)._get(SERVICE_BASE_PATHS['mgmt'], _url, params=_params)
 
         if not isinstance(entities, GeneratorType) and not isinstance(entities, Iterator):
             return self._return_class(entities, child, child_id, entity, collection)
@@ -369,7 +369,7 @@ class T1(Connection):
         Pages over 100 entities.
         This method should not be called directly: it's called from T1.get.
         """
-        _, num_recs = super(T1, self)._get(PATHS['mgmt'], kwargs['_url'], params={
+        _, num_recs = super(T1, self)._get(SERVICE_BASE_PATHS['mgmt'], kwargs['_url'], params={
             'page_limit': 1,
             'parent': kwargs.get('parent'),
             'q': kwargs.get('query')

--- a/terminalone/service.py
+++ b/terminalone/service.py
@@ -347,7 +347,7 @@ class T1(Connection):
             _params = self._construct_params(entity, include, full, page_limit,
                                              page_offset, sort_by, parent, query)
 
-        entities, ent_count = super(T1, self)._get(SERVICE_BASE_PATHS['mgmt'], _url, params=_params)
+        entities, ent_count = super(T1, self)._get(self._get_service_path(collection), _url, params=_params)
 
         if not isinstance(entities, GeneratorType) and not isinstance(entities, Iterator):
             return self._return_class(entities, child, child_id, entity, collection)
@@ -369,7 +369,7 @@ class T1(Connection):
         Pages over 100 entities.
         This method should not be called directly: it's called from T1.get.
         """
-        _, num_recs = super(T1, self)._get(SERVICE_BASE_PATHS['mgmt'], kwargs['_url'], params={
+        _, num_recs = super(T1, self)._get(self._get_service_path(collection), kwargs['_url'], params={
             'page_limit': 1,
             'parent': kwargs.get('parent'),
             'q': kwargs.get('query')

--- a/terminalone/t1types.py
+++ b/terminalone/t1types.py
@@ -3,6 +3,7 @@
 
 from datetime import datetime
 from terminalone.utils import FixedOffset
+import re
 
 
 def int_to_bool(value):
@@ -49,11 +50,16 @@ def default_empty(default):
 
 def strpt(dt_string):
     """Convert ISO string time to datetime.datetime. No-op on datetimes"""
+    # 2016-11-07T09:07:57
+    # 2016-11-07T09:07:57+0000
+    # 2016-11-16T12:31:10+00:00
+    offset_re = re.compile('([-+][0-9:]+$)')
     if isinstance(dt_string, datetime):
         return dt_string
-    if dt_string[-5] == '-' or dt_string[-5] == '+':
-        offset_str = dt_string[-5:]
-        dt_string = dt_string[:-5]
+    matches = re.split(offset_re, dt_string)
+    dt_string = matches[0]
+    if len(matches) > 1:
+        offset_str = matches[1].replace(':', '')
         offset = int(offset_str[-4:-2]) * 60 + int(offset_str[-2:])
         if offset_str[0] == "-":
             offset = -offset

--- a/terminalone/t1types.py
+++ b/terminalone/t1types.py
@@ -69,7 +69,7 @@ def strpt(dt_string):
     return datetime.strptime(dt_string, "%Y-%m-%dT%H:%M:%S").replace(tzinfo=FixedOffset(offset))
 
 
-def strft(dt_obj, null_on_none=False):
+def strft(dt_obj, null_on_none=False, offset=False):
     """Convert datetime.datetime to ISO string.
 
     :param null_on_none: bool Occasionally, we will actually want to send an
@@ -82,11 +82,16 @@ def strft(dt_obj, null_on_none=False):
         should be nulled out. In cases like this, null_on_none should be set
         to True in the entity's _push dict using a partial to make it a
         single-argument function. See strategy.py
+    :param offset: bool Whether to add the timezone offset
     :raise AttributeError: if not provided a datetime
     :return: str
     """
+
     try:
-        return dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
+        dt_str = dt_obj.strftime("%Y-%m-%dT%H:%M:%S")
+        if offset:
+            dt_str += dt_obj.strftime("%z")
+        return dt_str
     except AttributeError:
         if dt_obj is None and null_on_none:
             return ""

--- a/tests/fixtures/json/media_api_deal.json
+++ b/tests/fixtures/json/media_api_deal.json
@@ -1,7 +1,7 @@
 {
   "data": {
     "supply_source_id": 4,
-    "id": 139315,
+    "id": 11111,
     "name": "Test deal",
     "price": {
       "value": "4.3200",
@@ -13,18 +13,21 @@
     "permissions": {
       "all_organizations": false,
       "organization_ids": [],
-      "agency_ids": [],
+      "agency_ids": [
+        1234
+      ],
       "advertiser_ids": [
-        105186
+        12345,
+        123456
       ]
     },
     "sub_supply_source_id": null,
     "end_datetime": "2999-12-31T00:00:00+00:00",
     "status": true,
-    "deal_identifier": "266897",
+    "deal_identifier": "Deal_identifier",
     "start_datetime": "2016-11-16T12:31:10+00:00",
     "owner": {
-      "id": 105186,
+      "id": 22222,
       "type": "ADVERTISER"
     },
     "updated_on": "2016-11-16T11:31:53+00:00",

--- a/tests/fixtures/json/media_api_deal.json
+++ b/tests/fixtures/json/media_api_deal.json
@@ -1,0 +1,36 @@
+{
+  "data": {
+    "supply_source_id": 4,
+    "id": 139315,
+    "name": "Test deal",
+    "price": {
+      "value": "4.3200",
+      "currency_code": "EUR"
+    },
+    "created_on": "2016-11-16T11:31:53+00:00",
+    "entity_type": "deal",
+    "price_type": "FLOOR",
+    "permissions": {
+      "all_organizations": false,
+      "organization_ids": [],
+      "agency_ids": [],
+      "advertiser_ids": [
+        105186
+      ]
+    },
+    "sub_supply_source_id": null,
+    "end_datetime": "2999-12-31T00:00:00+00:00",
+    "status": true,
+    "deal_identifier": "266897",
+    "start_datetime": "2016-11-16T12:31:10+00:00",
+    "owner": {
+      "id": 105186,
+      "type": "ADVERTISER"
+    },
+    "updated_on": "2016-11-16T11:31:53+00:00",
+    "price_method": "CPM"
+  },
+  "meta": {
+    "status": "ok"
+  }
+}

--- a/tests/fixtures/json/media_api_error.json
+++ b/tests/fixtures/json/media_api_error.json
@@ -1,0 +1,12 @@
+{
+  "errors": [
+    {
+      "field": "sub_supply_source_id",
+      "message": "None is not of type 'integer'",
+      "code": "Input payload validation failed"
+    }
+  ],
+  "meta": {
+    "status": "error"
+  }
+}

--- a/tests/test_deals.py
+++ b/tests/test_deals.py
@@ -1,0 +1,89 @@
+from __future__ import absolute_import
+import unittest
+import responses
+import requests
+from .requests_patch import patched_extract_cookies_to_jar
+from terminalone import T1
+from terminalone.models import deal
+
+mock_credentials = {
+    'username': 'user',
+    'password': 'password',
+    'api_key': 'api_key',
+}
+
+API_BASE = 'api.mediamath.com'
+
+requests.sessions.extract_cookies_to_jar = patched_extract_cookies_to_jar
+requests.adapters.extract_cookies_to_jar = patched_extract_cookies_to_jar
+
+
+class TestDeals(unittest.TestCase):
+    @responses.activate
+    def setUp(self):
+        """set up test fixtures"""
+        with open('tests/fixtures/xml/session.xml') as f:
+            fixture = f.read()
+        responses.add(responses.POST, 'https://api.mediamath.com/api/v2.0/login',
+                      body=fixture,
+                      adding_headers={
+                          'Set-Cookie': 'adama_session=1',
+                      },
+                      content_type='application/xml')
+
+        self.t1 = T1(auth_method='cookie',
+                     api_base=API_BASE,
+                     **mock_credentials)
+
+    @responses.activate
+    def test_collection(self):
+        with open('tests/fixtures/json/media_api_deal.json') as f:
+            fixture = f.read()
+        responses.add(responses.GET, 'https://api.mediamath.com/media/v1.0/deals/11111',
+                      body=fixture,
+                      content_type='application/json')
+        deal = self.t1.get('deals', 11111)
+        self.assertIsNone(deal.sub_supply_source_id)
+
+    def test_generate_json(self):
+        mock_deal_properties = {
+            "data": {
+                "supply_source_id": 4,
+                "id": 11111,
+                "name": "Test deal",
+                "price": {
+                    "value": "4.3200",
+                    "currency_code": "EUR"
+                },
+                "created_on": "2016-11-16T11:31:53+00:00",
+                "entity_type": "deal",
+                "price_type": "FLOOR",
+                "permissions": {
+                    "all_organizations": False,
+                    "organization_ids": [],
+                    "agency_ids": [
+                        1234,
+                    ],
+                    "advertiser_ids": [
+                        12345,
+                        123456
+                    ]
+                },
+                "sub_supply_source_id": None,
+                "end_datetime": "2999-12-31T00:00:00+00:00",
+                "status": True,
+                "deal_identifier": "Deal_identifier",
+                "start_datetime": "2016-11-16T12:31:10+00:00",
+                "owner": {
+                    "id": 22222,
+                    "type": "ADVERTISER"
+                },
+                "updated_on": "2016-11-16T11:31:53+00:00",
+                "price_method": "CPM"
+            },
+            "meta": {
+                "status": "ok"
+            }
+        }
+        test_deal = deal.Deal(None, properties=mock_deal_properties)
+        #data = test_deal._validate_write(test_deal.data)

--- a/tests/test_deals.py
+++ b/tests/test_deals.py
@@ -4,7 +4,6 @@ import responses
 import requests
 from .requests_patch import patched_extract_cookies_to_jar
 from terminalone import T1
-from terminalone.models import deal
 
 mock_credentials = {
     'username': 'user',
@@ -45,45 +44,14 @@ class TestDeals(unittest.TestCase):
         deal = self.t1.get('deals', 11111)
         self.assertIsNone(deal.sub_supply_source_id)
 
+    @responses.activate
     def test_generate_json(self):
-        mock_deal_properties = {
-            "data": {
-                "supply_source_id": 4,
-                "id": 11111,
-                "name": "Test deal",
-                "price": {
-                    "value": "4.3200",
-                    "currency_code": "EUR"
-                },
-                "created_on": "2016-11-16T11:31:53+00:00",
-                "entity_type": "deal",
-                "price_type": "FLOOR",
-                "permissions": {
-                    "all_organizations": False,
-                    "organization_ids": [],
-                    "agency_ids": [
-                        1234,
-                    ],
-                    "advertiser_ids": [
-                        12345,
-                        123456
-                    ]
-                },
-                "sub_supply_source_id": None,
-                "end_datetime": "2999-12-31T00:00:00+00:00",
-                "status": True,
-                "deal_identifier": "Deal_identifier",
-                "start_datetime": "2016-11-16T12:31:10+00:00",
-                "owner": {
-                    "id": 22222,
-                    "type": "ADVERTISER"
-                },
-                "updated_on": "2016-11-16T11:31:53+00:00",
-                "price_method": "CPM"
-            },
-            "meta": {
-                "status": "ok"
-            }
-        }
-        test_deal = deal.Deal(None, properties=mock_deal_properties)
-        # data = test_deal._validate_write(test_deal.data)
+
+        with open('tests/fixtures/json/media_api_deal.json') as f:
+            fixture = f.read()
+        responses.add(responses.GET, 'https://api.mediamath.com/media/v1.0/deals/11111',
+                      body=fixture,
+                      content_type='application/json')
+        test_deal = self.t1.get('deals', 11111)
+        data = test_deal._validate_json_post(test_deal.properties)
+        self.assertEqual(data.get('start_datetime'), "2016-11-16T12:31:10+00:00")

--- a/tests/test_deals.py
+++ b/tests/test_deals.py
@@ -54,4 +54,4 @@ class TestDeals(unittest.TestCase):
                       content_type='application/json')
         test_deal = self.t1.get('deals', 11111)
         data = test_deal._validate_json_post(test_deal.properties)
-        self.assertEqual(data.get('start_datetime'), "2016-11-16T12:31:10+00:00")
+        self.assertEqual(data.get('start_datetime'), "2016-11-16T12:31:10+0000")

--- a/tests/test_deals.py
+++ b/tests/test_deals.py
@@ -86,4 +86,4 @@ class TestDeals(unittest.TestCase):
             }
         }
         test_deal = deal.Deal(None, properties=mock_deal_properties)
-        #data = test_deal._validate_write(test_deal.data)
+        # data = test_deal._validate_write(test_deal.data)

--- a/tests/test_jsonparser.py
+++ b/tests/test_jsonparser.py
@@ -3,7 +3,7 @@ from terminalone.jsonparser import JSONParser
 from terminalone import errors
 
 
-class TestXMLParsing(unittest.TestCase):
+class TestJSONParsing(unittest.TestCase):
     def test_auth_error(self):
         with open('tests/fixtures/json/auth_error.json') as f:
             fixture = f.read()

--- a/tests/test_jsonparser.py
+++ b/tests/test_jsonparser.py
@@ -50,3 +50,10 @@ class TestXMLParsing(unittest.TestCase):
         parser = JSONParser(fixture)
         self.assertEqual(True, parser.status_code)
         self.assertEqual(3, parser.entity_count)
+
+    def test_media_service_deals(self):
+        with open('tests/fixtures/json/media_api_deal.json') as f:
+            fixture = f.read()
+        parser = JSONParser(fixture)
+        self.assertEqual(True, parser.status_code)
+        self.assertEqual(1, parser.entity_count)

--- a/tests/test_t1types.py
+++ b/tests/test_t1types.py
@@ -1,0 +1,54 @@
+import unittest
+from terminalone import t1types
+
+
+class TestT1Types(unittest.TestCase):
+    def test_strpt(self):
+        date_one = '2016-11-07T09:07:57'
+        date_two = '2016-11-07T09:07:57+1000'
+        date_three = '2016-11-07T09:07:57+01:00'
+
+        dt_one = t1types.strpt(date_one)
+        dt_two = t1types.strpt(date_two)
+        dt_three = t1types.strpt(date_three)
+
+        self.assertEqual(2016, dt_one.year)
+        self.assertEqual(2016, dt_two.year)
+        self.assertEqual(2016, dt_three.year)
+
+        self.assertEqual(11, dt_one.month)
+        self.assertEqual(11, dt_two.month)
+        self.assertEqual(11, dt_three.month)
+
+        self.assertEqual(7, dt_one.day)
+        self.assertEqual(7, dt_two.day)
+        self.assertEqual(7, dt_three.day)
+
+        self.assertEqual(9, dt_one.hour)
+        self.assertEqual(9, dt_two.hour)
+        self.assertEqual(9, dt_three.hour)
+
+        self.assertEqual(7, dt_one.minute)
+        self.assertEqual(7, dt_two.minute)
+        self.assertEqual(7, dt_three.minute)
+
+        self.assertEqual(57, dt_one.second)
+        self.assertEqual(57, dt_two.second)
+        self.assertEqual(57, dt_three.second)
+
+        self.assertEqual(0, dt_one.tzinfo.utcoffset().seconds)
+        self.assertEqual(36000, dt_two.tzinfo.utcoffset().seconds)
+        self.assertEqual(3600, dt_three.tzinfo.utcoffset().seconds)
+
+    def test_strft(self):
+        date_str = '2016-11-07T09:07:57+01:00'
+        expected_no_offset = '2016-11-07T09:07:57'
+        expected_offset = '2016-11-07T09:07:57+0100'
+
+        dt_obj = t1types.strpt(date_str)
+
+        self.assertEqual(expected_no_offset, t1types.strft(dt_obj))
+        self.assertEqual(expected_offset, t1types.strft(dt_obj, offset=True))
+        self.assertEqual("", t1types.strft(None, null_on_none=True))
+        with self.assertRaises(AttributeError):
+            t1types.strft(None)


### PR DESCRIPTION
Some new things happening here to support the new Deals service and the deprecation of the old endpoints

The `strategies` entity now allows for `save_deals()` alongside `save_supplies()`- the syntax here is the same as saving supplies.  to use, call the strategy with `child=deals` (optional), then call strategy.save_deals with `data=[dict of deals]` 

Asking for a `deal` entity now talks to the new media API and pulls the json entity. saving will also post to this endpoint in json format.

entities are now aware of whether they should be posting formdata or json. 