### PR TITLE
Release script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open(ver_path) as ver_file:
 
 def check_pip():
     st = subprocess.check_output('pip search {}'.format(metadata['__name__']), shell=True)
-    pip_version = st[st.index('(')+1: st.index(')')]
+    pip_version = st[st.index('(') + 1: st.index(')')]
     print(pip_version)
     if pip_version == metadata['__version__']:
         print('version {} already published. '

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 from __future__ import print_function
-from __future__ import absolute_import
 import os
 import sys
 import subprocess
@@ -38,7 +37,7 @@ with open(ver_path) as ver_file:
 
 
 def check_pip():
-    st = subprocess.check_output('pip search {}'.format(metadata['__name__']), shell=True)
+    st = subprocess.check_output(['pip', 'search', metadata['__name__']])
     pip_version = st[st.index('(') + 1: st.index(')')]
     print(pip_version)
     if pip_version == metadata['__version__']:
@@ -49,25 +48,27 @@ def check_pip():
 
 if sys.argv[-1] == 'publish':
     check_pip()
-    os.system("python setup.py sdist")
+    subprocess.call(["python", "setup.py", "sdist"])
     filename = "TerminalOne-{}.tar.gz".format(metadata['__version__'])
     print('Uploading {}'.format(filename))
-    os.system("twine upload dist/{}".format(filename))
+    subprocess.call(["twine", "upload", "dist/{}".format(filename)])
     print("Did you remember to tag the release? ./setup.py tag")
     sys.exit()
 
 if sys.argv[-1] == 'tag':
-    os.system("git tag -a %s -m 'version %s'" % (metadata['__version__'], metadata['__version__']))
-    os.system("git push --tags")
+    subprocess.call(["git", "tag",
+                     "-a", metadata['__version__'],
+                     "-m", "'version {}'".format(metadata['__version__'])])
+    subprocess.call(["git", "push", "--tags"])
     sys.exit()
 
 setup(
     name=metadata['__name__'],
     version=metadata['__version__'],
     author=metadata['__author__'],
-    author_email='prasanna@mediamath.com',
-    url='http://www.mediamath.com',
-    description="A package for interacting with MediaMath's TerminalOne API.",
+    author_email=metadata['__email__'],
+    url=metadata['__url__'],
+    description=metadata['__description__'],
     long_description=fread('README.rst'),
     packages=packages,
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,16 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import absolute_import
+import os
+import sys
+import subprocess
+from distutils.util import convert_path
+
 
 try:
     from setuptools import setup
 except ImportError:
     from distutils.core import setup
-import os
 
 CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -12,7 +18,6 @@ CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 def fread(fname):
     with open(os.path.join(CURRENT_DIR, fname)) as f:
         return f.read()
-
 
 packages = [
     'terminalone',
@@ -26,10 +31,40 @@ requirements = [
     'requests-oauthlib>=0.5.0',
 ]
 
+metadata = {}
+ver_path = convert_path('terminalone/metadata.py')
+with open(ver_path) as ver_file:
+    exec(ver_file.read(), metadata)
+
+
+def check_pip():
+    st = subprocess.check_output('pip search {}'.format(metadata['__name__']), shell=True)
+    pip_version = st[st.index('(')+1: st.index(')')]
+    print(pip_version)
+    if pip_version == metadata['__version__']:
+        print('version {} already published. '
+              'Modify metadata.py to update version and commit.'
+              .format(pip_version))
+        sys.exit()
+
+if sys.argv[-1] == 'publish':
+    check_pip()
+    os.system("python setup.py sdist")
+    filename = "TerminalOne-{}.tar.gz".format(metadata['__version__'])
+    print('Uploading {}'.format(filename))
+    os.system("twine upload dist/{}".format(filename))
+    print("Did you remember to tag the release? ./setup.py tag")
+    sys.exit()
+
+if sys.argv[-1] == 'tag':
+    os.system("git tag -a %s -m 'version %s'" % (metadata['__version__'], metadata['__version__']))
+    os.system("git push --tags")
+    sys.exit()
+
 setup(
-    name='TerminalOne',
-    version='1.6.0',
-    author='Prasanna Swaminathan',
+    name=metadata['__name__'],
+    version=metadata['__version__'],
+    author=metadata['__author__'],
     author_email='prasanna@mediamath.com',
     url='http://www.mediamath.com',
     description="A package for interacting with MediaMath's TerminalOne API.",

--- a/terminalone/metadata.py
+++ b/terminalone/metadata.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 
 __name__ = 'TerminalOne'
-__author__ = 'Prasanna Swaminathan'
+__author__ = 'MediaMath'
 __copyright__ = 'Copyright 2015, MediaMath'
 __license__ = 'Apache License, Version 2.0'
 __version__ = '1.6.0'
 __maintainer__ = 'MediaMath Developer Relations'
 __email__ = 'developers@mediamath.com'
 __status__ = 'Stable'
+__url__ = 'http://www.mediamath.com'
+__description__ = "A package for interacting with MediaMath's TerminalOne API."

--- a/terminalone/metadata.py
+++ b/terminalone/metadata.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+__name__ = 'TerminalOne'
 __author__ = 'Prasanna Swaminathan'
 __copyright__ = 'Copyright 2015, MediaMath'
 __license__ = 'Apache License, Version 2.0'

--- a/tests/test_oauth2.py
+++ b/tests/test_oauth2.py
@@ -1,10 +1,8 @@
 from __future__ import absolute_import
-import json
 from time import time
 import unittest
 import responses
-import requests
-from terminalone import T1, errors
+from terminalone import T1
 from terminalone.vendor import six
 
 mock_credentials = {


### PR DESCRIPTION
Make setup.py executable 
move all metadata field definitions into metadata.py
add `tag` and `publish` commands to setup.py to reduce the overheads in pushing to pypi.org