### PR TITLE
properties -> _properties

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -360,16 +360,13 @@ access that entity's properties using instance attributes:
 -  ``save(data=None)``
    Save the entity. If ``data`` is provided, send that. Typically used
    with no arguments.
--  ``properties``
-   Dictionary of entity properties
-
 (*Note: you will typically interact with subclasses, not ``Entity``
 itself*)
 
 If for some reason you need to access the object like a dictionary (for
-instance, if you need to iterate over fields or dump to a CSV), the dict
-``properties`` is available. However, you shouldn't modify
-``properties`` directly, as it bypasses validation.
+instance, if you need to iterate over fields or dump to a CSV), the method
+``get_properties()`` is available. However, you shouldn't modify
+``_properties`` directly, as it will cause incorrect behaviour.
 
 Once you have your instance, you can modify its values, and then save it
 back. A return value of ``None`` indicates success. Otherwise, an error

--- a/terminalone/models/campaign.py
+++ b/terminalone/models/campaign.py
@@ -107,6 +107,6 @@ class Campaign(Entity):
     def save(self, data=None, url=None):
         """Save object to T1 while accounting for old fields"""
         if data is None:
-            data = self.properties.copy()
+            data = self._properties.copy()
 
         super(Campaign, self).save(data=data, url=url)

--- a/terminalone/models/permission.py
+++ b/terminalone/models/permission.py
@@ -41,7 +41,7 @@ class Permission(SubEntity):
     def __init__(self, session, properties=None, **kwargs):
         super(Permission, self).__init__(session, properties, **kwargs)
         # we need to do 'full fat' posts on permissions, so override all the _init_properties
-        self.properties.update(self._init_properties)
+        self._properties.update(self._init_properties)
 
     def _change_access(self, entity_access, id_to_change, add):
         entity_hierarchy = ['advertiser',
@@ -50,17 +50,17 @@ class Permission(SubEntity):
         if entity_access not in entity_hierarchy:
             raise ClientError('Must be one of {}!'.format(entity_hierarchy))
         if add:
-            if not self.properties.get(entity_access):
-                self.properties[entity_access] = {}
-            self.properties[entity_access][id_to_change] = "placeholder"
+            if not self._properties.get(entity_access):
+                self._properties[entity_access] = {}
+            self._properties[entity_access][id_to_change] = "placeholder"
         else:
-            self.properties[entity_access].pop(id_to_change)
+            self._properties[entity_access].pop(id_to_change)
             depth = entity_hierarchy.index(entity_access)
             if depth > 0:
                 child_entity = entity_hierarchy[depth - 1]
                 parent_key = entity_access + '_id'
                 children_to_remove = []
-                for entity_id, entity in six.iteritems(self.properties[child_entity]):
+                for entity_id, entity in six.iteritems(self._properties[child_entity]):
                     if entity[parent_key] == id_to_change:
                         children_to_remove.append(entity_id)
                 for entity_id in children_to_remove:
@@ -84,14 +84,14 @@ class Permission(SubEntity):
 
     def _generate_save_data(self, data=None):
         if data is None:
-            data = self.properties.copy()
+            data = self._properties.copy()
         data.pop('organization', None)
         data.pop('agency', None)
         data.pop('advertiser', None)
-        if self.properties['advertiser'] is not None:
-            data['advertiser_id'] = self.properties['advertiser'].keys()
-        if self.properties['agency'] is not None:
-            data['agency_id'] = self.properties['agency'].keys()
-        if self.properties['organization'] is not None:
-            data['organization_id'] = self.properties['organization'].keys()
+        if self._properties['advertiser'] is not None:
+            data['advertiser_id'] = self._properties['advertiser'].keys()
+        if self._properties['agency'] is not None:
+            data['agency_id'] = self._properties['agency'].keys()
+        if self._properties['organization'] is not None:
+            data['organization_id'] = self._properties['organization'].keys()
         return data

--- a/terminalone/models/pixel.py
+++ b/terminalone/models/pixel.py
@@ -41,5 +41,5 @@ class ChildPixel(Entity):
                         str(self.id),
                         'delete'])
         self._post(self._get_service_path(), rest=url, data={'version': self.version})
-        for item in list(self.properties.keys()):
-            del self.properties[item]
+        for item in list(self._properties.keys()):
+            del self._properties[item]

--- a/terminalone/models/pixelbundle.py
+++ b/terminalone/models/pixelbundle.py
@@ -85,7 +85,7 @@ class Pixel(Entity):
             return super(Pixel, self).save(data=data)
 
         if data is None:
-            data = self.properties.copy()
+            data = self._properties.copy()
         if self.pricing == 'CPM':
             data.pop('cost_cpts', None)
             if not getattr(self, 'cost_pct_cpm', None):

--- a/terminalone/models/placementslot.py
+++ b/terminalone/models/placementslot.py
@@ -88,5 +88,5 @@ class PlacementSlot(Entity):
 
     def save(self, data=None, url=None):
         """Set defaults for object before saving"""
-        update_low_priority(self.properties, self.defaults)
+        update_low_priority(self._properties, self.defaults)
         super(PlacementSlot, self).save()

--- a/terminalone/models/siteplacement.py
+++ b/terminalone/models/siteplacement.py
@@ -43,7 +43,7 @@ class SitePlacement(Entity):
 
     def save(self, data=None, url=None):
         if data is None:
-            data = self.properties
+            data = self._properties
         if not data.get('display_text'):
             data['display_text'] = data['name']
         super(SitePlacement, self).save(data=data, url=url)

--- a/terminalone/models/strategy.py
+++ b/terminalone/models/strategy.py
@@ -175,8 +175,8 @@ class Strategy(Entity):
         entity, _ = super(Strategy, self)._post(self._get_service_path(), url, data)
         self._update_self(entity)
         self._deserialize_target_expr()
-        if 'relations' in self.properties:
-            del self.properties['relations']
+        if 'relations' in self._properties:
+            del self._properties['relations']
 
     def save_domains(self, data):
         url = self._construct_url(addl=['domain_restrictions', ])
@@ -213,15 +213,15 @@ class Strategy(Entity):
     def save(self, data=None, url=None):
         """Save object to T1 accounting for fields an pixel target expr"""
         if data is None:
-            data = self.properties.copy()
+            data = self._properties.copy()
 
         data['pixel_target_expr'] = self._serialize_target_expr()
 
         if getattr(self, 'use_campaign_start', False) and 'start_date' in data:
-            self.properties.pop('start_date', None)
+            self._properties.pop('start_date', None)
             data['start_date'] = None
         if getattr(self, 'use_campaign_end', False) and 'end_date' in data:
-            self.properties.pop('end_date', None)
+            self._properties.pop('end_date', None)
             data['end_date'] = None
 
         super(Strategy, self).save(data=data, url=url)

--- a/terminalone/models/strategyaudiencesegment.py
+++ b/terminalone/models/strategyaudiencesegment.py
@@ -46,5 +46,5 @@ class StrategyAudienceSegment(Entity):
             'include_op': 'OR',
         }
         self._post(self._get_service_path(), rest=url, data=data)
-        for item in list(self.properties.keys()):
-            del self.properties[item]
+        for item in list(self._properties.keys()):
+            del self._properties[item]

--- a/terminalone/models/strategyconcept.py
+++ b/terminalone/models/strategyconcept.py
@@ -42,5 +42,5 @@ class StrategyConcept(Entity):
                         str(self.id),
                         'delete'])
         self._post(self._get_service_path(), rest=url, data={'version': self.version})
-        for item in list(self.properties.keys()):
-            del self.properties[item]
+        for item in list(self._properties.keys()):
+            del self._properties[item]

--- a/terminalone/models/strategydaypart.py
+++ b/terminalone/models/strategydaypart.py
@@ -40,5 +40,5 @@ class StrategyDayPart(Entity):
                         str(self.id),
                         'delete'])
         self._post(self._get_service_path(), rest=url, data={'version': self.version})
-        for item in list(self.properties.keys()):
-            del self.properties[item]
+        for item in list(self._properties.keys()):
+            del self._properties[item]

--- a/terminalone/models/strategytargetingsegment.py
+++ b/terminalone/models/strategytargetingsegment.py
@@ -48,5 +48,5 @@ class StrategyTargetingSegment(Entity):
             'include_op': 'OR',
         }
         self._post(self._get_service_path(), rest=url, data=data)
-        for item in list(self.properties.keys()):
-            del self.properties[item]
+        for item in list(self._properties.keys()):
+            del self._properties[item]


### PR DESCRIPTION
Also add a getter function `get_properties()` which returns a dict of all the current fields. 
Making `properties` implicitly private discourages interacting with `Entity.properties` directly, which:
* was never supported 
* breaks validation
* breaks incremental posting
* creates user confusion when it's empty (properties on freshly pulled entities go into `_init_properties`)