### PR TITLE
Allow Requests session to be passed to T1 constructor

### DIFF
--- a/terminalone/connection.py
+++ b/terminalone/connection.py
@@ -29,6 +29,7 @@ class Connection(object):
                  api_base=None,
                  json=False,
                  auth_params=None,
+                 session=None,
                  _create_session=False):
         """Set up Requests Session to be used for all connections to T1.
 
@@ -66,11 +67,12 @@ class Connection(object):
         Connection.__setattr__(self, 'json', json)
         Connection.__setattr__(self, 'auth_params', auth_params)
         if _create_session:
-            self._create_session()
+            self._create_session(session=session)
 
-    def _create_session(self):
+    def _create_session(self, session=None):
         method = self.auth_params['method']
-        session = Session()
+        if session is None:
+            session = Session()
         session.headers['User-Agent'] = self.user_agent
         if method not in ['oauth2-resourceowner',
                           'oauth2-existingaccesstoken']:


### PR DESCRIPTION
This would ease some of the use cases like retrying requests with `urllib3.util.retry` or adding performance logging. Right now we have to rely on hacks like replacing global `requests.Session` which is undesirable for obvious reasons.